### PR TITLE
ldd-check: Preserve LD_LIBRARY_PATH when checking python libs

### DIFF
--- a/ldd-check/ldd-check
+++ b/ldd-check/ldd-check
@@ -91,7 +91,7 @@ check_file() {
   case "$f" in
     *python*site-packages*)
       [ -n "$ld_library_path" ] && ld_library_path=$ld_library_path:
-      ld_library_path=$(dirname "$f")
+      ld_library_path="${ld_library_path}$(dirname "$f")"
       vmsg "Added python site package directory to ld_library_path, result is $ld_library_path"
   esac
 


### PR DESCRIPTION
This appears to have been the intent.