### PR TITLE
tw/twt and ptrace

### DIFF
--- a/go.work.sum
+++ b/go.work.sum
@@ -25,6 +25,7 @@ github.com/alecthomas/units v0.0.0-20211218093645-b94a6e3cc137/go.mod h1:OMCwj8V
 github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be/go.mod h1:ySMOLuWl6zY27l47sB3qLNK6tF2fkHG55UZxx8oIVo4=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/antlr4-go/antlr/v4 v4.13.0/go.mod h1:pfChB/xh/Unjila75QW7+VU4TSnWnnk9UTnmpPaOR2g=
+github.com/armon/go-radix v1.0.0 h1:F4z6KzEeeQIMeLFa97iZU6vupzoecKdU5TX24SNppXI=
 github.com/armon/go-radix v1.0.0/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
 github.com/atotto/clipboard v0.1.4/go.mod h1:ZY9tmq7sm5xIbd9bOK4onWV4S6X0u6GY7Vn0Yu86PYI=
 github.com/aws/aws-sdk-go-v2 v1.34.0/go.mod h1:JgstGg0JjWU1KpVJjD5H0y0yyAIpSdKEq556EI6yOOM=

--- a/melange.yaml
+++ b/melange.yaml
@@ -1,6 +1,6 @@
 package:
   name: tw
-  version: 0.0.3
+  version: 0.0.0
   epoch: 0
   description: Testing tools
   options:
@@ -33,6 +33,14 @@ pipeline:
   - uses: strip
 
 subpackages:
+  - name: twt
+    options:
+      no-provides: true
+    pipeline:
+      - runs: |
+          install -Dm755 tw/bin/twt ${{targets.contextdir}}/usr/bin/twt
+      - uses: strip
+
   - name: ldd-check
     options:
       no-provides: true

--- a/tw/Makefile
+++ b/tw/Makefile
@@ -6,10 +6,11 @@ MELANGE_INSTALL_PATH = $(MELANGE_CONTEXTDIR)/usr
 
 build:
 	mkdir -p bin
-	go test -c -o bin/tw
+	go build -o bin/tw
 	for cmd in `bin/tw list-multicalls`; do \
 		ln -sf tw bin/$$cmd && echo "Created symlink for $$cmd"; \
 	done
+	go test -c -o bin/twt
 
 melange-install: build
 	echo $@

--- a/tw/go.mod
+++ b/tw/go.mod
@@ -4,6 +4,7 @@ go 1.24
 
 require (
 	chainguard.dev/apko v0.25.1
+	github.com/armon/go-radix v1.0.0
 	github.com/avast/retry-go/v4 v4.6.0
 	github.com/chainguard-dev/clog v1.6.1
 	github.com/google/go-containerregistry v0.20.3
@@ -11,6 +12,7 @@ require (
 	github.com/rogpeppe/go-internal v1.13.1
 	github.com/spf13/cobra v1.9.1
 	golang.org/x/sync v0.11.0
+	golang.org/x/sys v0.30.0
 	helm.sh/helm/v3 v3.17.1
 	k8s.io/api v0.32.2
 	k8s.io/apimachinery v0.32.2
@@ -150,7 +152,6 @@ require (
 	golang.org/x/exp v0.0.0-20250218142911-aa4b98e5adaa // indirect
 	golang.org/x/net v0.35.0 // indirect
 	golang.org/x/oauth2 v0.26.0 // indirect
-	golang.org/x/sys v0.30.0 // indirect
 	golang.org/x/term v0.29.0 // indirect
 	golang.org/x/text v0.22.0 // indirect
 	golang.org/x/time v0.10.0 // indirect

--- a/tw/go.sum
+++ b/tw/go.sum
@@ -40,6 +40,8 @@ github.com/Microsoft/hcsshim v0.11.7 h1:vl/nj3Bar/CvJSYo7gIQPyRWc9f3c6IeSNavBTSZ
 github.com/Microsoft/hcsshim v0.11.7/go.mod h1:MV8xMfmECjl5HdO7U/3/hFVnkmSBjAjmA09d4bExKcU=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
+github.com/armon/go-radix v1.0.0 h1:F4z6KzEeeQIMeLFa97iZU6vupzoecKdU5TX24SNppXI=
+github.com/armon/go-radix v1.0.0/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 h1:DklsrG3dyBCFEj5IhUbnKptjxatkF07cF2ak3yi77so=

--- a/tw/main.go
+++ b/tw/main.go
@@ -1,1 +1,66 @@
 package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/chainguard-dev/tw/pkg/commands/kgrep"
+	"github.com/chainguard-dev/tw/pkg/commands/kimages"
+	"github.com/chainguard-dev/tw/pkg/commands/sfuzz"
+	"github.com/chainguard-dev/tw/pkg/commands/shu"
+	"github.com/chainguard-dev/tw/pkg/commands/wassert"
+	"github.com/spf13/cobra"
+)
+
+var cmds = map[string]*cobra.Command{
+	"sfuzz":   sfuzz.Command(),
+	"kgrep":   kgrep.Command(),
+	"kimages": kimages.Command(),
+	"wassert": wassert.Command(),
+	"shu":     shu.Command(),
+}
+
+func main() {
+	// First check if we're being called as a multicall
+	ename := filepath.Base(os.Args[0])
+	if cmd, ok := cmds[ename]; ok {
+		if err := cmd.Execute(); err != nil {
+			os.Exit(1)
+		}
+		os.Exit(0)
+	}
+
+	// If not a multicall, then build the regular command hierarchy
+	cmd := &cobra.Command{
+		Use:          "tw",
+		SilenceUsage: true,
+	}
+
+	for _, c := range cmds {
+		cmd.AddCommand(c)
+	}
+
+	// Add a helper command for creating the multicall symlinks
+		cmd.AddCommand(
+			&cobra.Command{
+				Use:    "list-multicalls",
+				Hidden: true,
+				Run: func(cmd *cobra.Command, args []string) {
+					names := make([]string, 0)
+					for _, c := range cmds {
+						names = append(names, c.Name())
+					}
+					sort.Strings(names)
+					fmt.Fprint(cmd.OutOrStdout(), strings.Join(names, " "))
+				},
+			},
+		)
+
+	if err := cmd.Execute(); err != nil {
+		os.Exit(1)
+	}
+	os.Exit(0)
+}

--- a/tw/main_linux.go
+++ b/tw/main_linux.go
@@ -1,0 +1,10 @@
+//go:build linux
+// +build linux
+
+package main
+
+import "github.com/chainguard-dev/tw/pkg/commands/ptrace"
+
+func init() {
+	cmds["ptrace"] = ptrace.Command()
+}

--- a/tw/main_linux_test.go
+++ b/tw/main_linux_test.go
@@ -1,0 +1,10 @@
+//go:build linux
+// +build linux
+
+package main_test
+
+import "github.com/chainguard-dev/tw/pkg/commands/ptrace"
+
+func init() {
+	cmds["tracer"] = ptrace.Command()
+}

--- a/tw/main_linux_test.go
+++ b/tw/main_linux_test.go
@@ -6,5 +6,5 @@ package main_test
 import "github.com/chainguard-dev/tw/pkg/commands/ptrace"
 
 func init() {
-	cmds["tracer"] = ptrace.Command()
+	cmds["ptrace"] = ptrace.Command()
 }

--- a/tw/main_test.go
+++ b/tw/main_test.go
@@ -6,8 +6,6 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
-	"path/filepath"
-	"sort"
 	"strings"
 	"testing"
 
@@ -27,69 +25,16 @@ var (
 	update = flag.Bool("update", false, "update relevant golden files")
 )
 
-func TestMain(m *testing.M) {
-	// First check if we're being called as a multicall
-	ename := filepath.Base(os.Args[0])
-	if cmd, ok := cmds[ename]; ok {
-		if err := cmd.Execute(); err != nil {
-			os.Exit(1)
-		}
-		os.Exit(0)
-	}
-
-	// If its not a multicall, then just build the regular command hierarchy
-	cmd := &cobra.Command{
-		Use:          "tw",
-		SilenceUsage: true,
-	}
-
-	for _, c := range cmds {
-		cmd.AddCommand(c)
-	}
-
-	// Add the special test subcommand
-	cmd.AddCommand(
-		&cobra.Command{
-			Use:                "test",
-			DisableFlagParsing: true,
-			Run: func(cmd *cobra.Command, args []string) {
-				// Parse test flags after removing "test" from args
-				// This allows `tw test --script foo` to work like `go test --args --script foo`
-				os.Args = append([]string{os.Args[0]}, args...)
-				flag.Parse()
-				os.Exit(m.Run())
-			},
-		},
-	)
-
-	// Add a helper command for creating the multicall symlinks
-	cmd.AddCommand(
-		&cobra.Command{
-			Use:    "list-multicalls",
-			Hidden: true,
-			Run: func(cmd *cobra.Command, args []string) {
-				names := make([]string, 0)
-				for _, c := range cmds {
-					names = append(names, c.Name())
-				}
-				sort.Strings(names)
-				fmt.Fprint(cmd.OutOrStdout(), strings.Join(names, " "))
-			},
-		},
-	)
-
-	if err := cmd.Execute(); err != nil {
-		os.Exit(1)
-	}
-	os.Exit(0)
-}
-
 var cmds = map[string]*cobra.Command{
 	"sfuzz":   sfuzz.Command(),
 	"kgrep":   kgrep.Command(),
 	"kimages": kimages.Command(),
 	"wassert": wassert.Command(),
 	"shu":     shu.Command(),
+}
+
+func TestMain(m *testing.M) {
+	os.Exit(m.Run())
 }
 
 func TestScript(t *testing.T) {
@@ -114,10 +59,7 @@ func TestScript(t *testing.T) {
 		Files:         files,
 		Dir:           *dir,
 		UpdateScripts: *update,
-		Setup: func(e *testscript.Env) error {
-			return os.Chdir(e.WorkDir)
-		},
-		Cmds: tscmds,
+		Cmds:          tscmds,
 	})
 }
 

--- a/tw/main_test.go
+++ b/tw/main_test.go
@@ -28,8 +28,6 @@ var (
 )
 
 func TestMain(m *testing.M) {
-	cmds := commands()
-
 	// First check if we're being called as a multicall
 	ename := filepath.Base(os.Args[0])
 	if cmd, ok := cmds[ename]; ok {
@@ -86,14 +84,12 @@ func TestMain(m *testing.M) {
 	os.Exit(0)
 }
 
-func commands() map[string]*cobra.Command {
-	return map[string]*cobra.Command{
-		"sfuzz":   sfuzz.Command(),
-		"kgrep":   kgrep.Command(),
-		"kimages": kimages.Command(),
-		"wassert": wassert.Command(),
-		"shu":     shu.Command(),
-	}
+var cmds = map[string]*cobra.Command{
+	"sfuzz":   sfuzz.Command(),
+	"kgrep":   kgrep.Command(),
+	"kimages": kimages.Command(),
+	"wassert": wassert.Command(),
+	"shu":     shu.Command(),
 }
 
 func TestScript(t *testing.T) {
@@ -110,7 +106,7 @@ func TestScript(t *testing.T) {
 	ctx := t.Context()
 
 	tscmds := map[string]func(ts *testscript.TestScript, neg bool, args []string){}
-	for n, cmd := range commands() {
+	for n, cmd := range cmds {
 		tscmds[n] = RegisterCmd(ctx, cmd)
 	}
 

--- a/tw/pkg/commands/ptrace/ptrace.go
+++ b/tw/pkg/commands/ptrace/ptrace.go
@@ -1,0 +1,362 @@
+//go:build linux
+// +build linux
+
+package ptrace
+
+import (
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+type cfg struct {
+	verbose       bool
+	summarize     bool
+	showReturns   bool
+	filterSyscall string
+	showCategory  bool
+}
+
+func Command() *cobra.Command {
+	cfg := &cfg{}
+
+	cmd := &cobra.Command{
+		Use:   "ptrace [command] [args...]",
+		Short: "Trace system calls made by a command",
+		Long: `Trace system calls made by a command and its child processes.
+This tool shows file operations, network activity, and process execution in real-time.`,
+		Example: `  tw ptrace ls -la
+  tw ptrace curl https://example.com
+  tw ptrace --verbose go build ./...`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return cfg.Run(cmd, args)
+		},
+	}
+
+	cmd.Flags().BoolVarP(&cfg.verbose, "verbose", "v", false, "Show more detailed syscall information")
+	cmd.Flags().BoolVarP(&cfg.summarize, "summarize", "s", true, "Show summary statistics at the end")
+	cmd.Flags().BoolVar(&cfg.showReturns, "show-returns", false, "Show syscall return values")
+	cmd.Flags().StringVar(&cfg.filterSyscall, "filter", "", "Only show syscalls matching this filter (comma-separated list)")
+	cmd.Flags().BoolVar(&cfg.showCategory, "categorize", false, "Group syscalls by category in summary")
+
+	return cmd
+}
+
+func (c *cfg) Run(cmd *cobra.Command, args []string) error {
+	if len(args) == 0 {
+		return fmt.Errorf("no command specified")
+	}
+
+	ctx := cmd.Context()
+	startTime := time.Now()
+
+	tracer, err := New(args, TracerOpts{
+		Args: args,
+	})
+	if err != nil {
+		return err
+	}
+
+	fmt.Fprintf(os.Stdout, "Tracing command: %s\n", strings.Join(args, " "))
+	fmt.Fprintf(os.Stdout, "Press Ctrl+C to stop tracing\n\n")
+
+	if err := tracer.Start(ctx); err != nil {
+		return err
+	}
+
+	// Create statistics trackers
+	stats := make(map[string]int)
+	fileOps := make(map[string]struct{})
+	execOps := make(map[string]struct{})
+	networkOps := make(map[string]struct{})
+	memoryOps := make(map[string]struct{})
+	processOps := make(map[string]struct{})
+	signalOps := make(map[string]struct{})
+	timeOps := make(map[string]struct{})
+	securityOps := make(map[string]struct{})
+	ipcOps := make(map[string]struct{})
+
+	// Create syscall filter if specified
+	var filters []string
+	if c.filterSyscall != "" {
+		filters = strings.Split(c.filterSyscall, ",")
+		for i, f := range filters {
+			filters[i] = strings.TrimSpace(f)
+		}
+	}
+
+	// Set up a done channel to signal event processing completion
+	eventsDone := make(chan struct{})
+
+	go func() {
+		defer close(eventsDone)
+		fmt.Fprintf(os.Stderr, "DEBUG: Starting event processing goroutine\n")
+		eventCount := 0
+
+		for {
+			select {
+			case e, ok := <-tracer.Events():
+				if !ok {
+					// Channel closed, we're done
+					fmt.Fprintf(os.Stderr, "DEBUG: Events channel closed, exiting event processor\n")
+					return
+				}
+				eventCount++
+				fmt.Fprintf(os.Stderr, "DEBUG: Received event #%d: %s (pid=%d) type=%v\n",
+					eventCount, e.SyscallName, e.Pid, e.Type)
+
+				// Skip if filtering is enabled and this syscall doesn't match
+				if len(filters) > 0 {
+					match := false
+					for _, f := range filters {
+						if strings.Contains(e.SyscallName, f) {
+							match = true
+							break
+						}
+					}
+					if !match {
+						fmt.Fprintf(os.Stderr, "DEBUG: Filtering out %s (doesn't match filters)\n", e.SyscallName)
+						continue
+					}
+				}
+
+				// Skip return events if not requested
+				if !c.showReturns && strings.HasSuffix(e.SyscallName, "-return") {
+					fmt.Fprintf(os.Stderr, "DEBUG: Skipping return event %s\n", e.SyscallName)
+					continue
+				}
+
+				// Track statistics for summary
+				prevCount, _ := stats[e.SyscallName]
+				stats[e.SyscallName]++
+				fmt.Fprintf(os.Stderr, "DEBUG: Incremented stats for %s: %d -> %d\n",
+					e.SyscallName, prevCount, stats[e.SyscallName])
+
+				// Track operations by category
+				if !strings.HasSuffix(e.SyscallName, "-return") {
+					// Track file operations
+					if IsFileOpSyscall(e.Syscall) {
+						if e.Path != "" {
+							fileOps[e.Path] = struct{}{}
+							fmt.Fprintf(os.Stderr, "DEBUG: Added file operation: %s\n", e.Path)
+						} else {
+							fmt.Fprintf(os.Stderr, "DEBUG: File operation with empty path for %s\n", e.SyscallName)
+						}
+					} else if e.Type == EventExec {
+						if e.Path != "" {
+							execOps[e.Path] = struct{}{}
+							fmt.Fprintf(os.Stderr, "DEBUG: Added exec operation: %s\n", e.Path)
+						}
+					}
+
+					// Track network operations
+					if IsNetworkSyscall(e.Syscall) {
+						networkOps[e.Path] = struct{}{}
+						fmt.Fprintf(os.Stderr, "DEBUG: Added network operation: %s\n", e.Path)
+					}
+
+					// Track by category for extended classification
+					if IsMemorySyscall(e.Syscall) {
+						memoryOps[e.SyscallName] = struct{}{}
+					}
+					if IsProcessSyscall(e.Syscall) {
+						processOps[e.SyscallName] = struct{}{}
+					}
+					if IsSignalSyscall(e.Syscall) {
+						signalOps[e.SyscallName] = struct{}{}
+					}
+					if IsTimeSyscall(e.Syscall) {
+						timeOps[e.SyscallName] = struct{}{}
+					}
+					if IsSecuritySyscall(e.Syscall) {
+						securityOps[e.SyscallName] = struct{}{}
+					}
+					if IsIpcSyscall(e.Syscall) {
+						ipcOps[e.SyscallName] = struct{}{}
+					}
+				}
+
+				// Format and print event
+				var eventStr string
+
+				if c.verbose {
+					var category string
+					if IsFileOpSyscall(e.Syscall) {
+						category = "file"
+					} else if IsNetworkSyscall(e.Syscall) {
+						category = "net"
+					} else if IsExecSyscall(e.Syscall) {
+						category = "exec"
+					} else if IsMemorySyscall(e.Syscall) {
+						category = "mem"
+					} else if IsProcessSyscall(e.Syscall) {
+						category = "proc"
+					} else if IsSignalSyscall(e.Syscall) {
+						category = "sig"
+					} else if IsTimeSyscall(e.Syscall) {
+						category = "time"
+					} else if IsSecuritySyscall(e.Syscall) {
+						category = "sec"
+					} else if IsIpcSyscall(e.Syscall) {
+						category = "ipc"
+					} else {
+						category = "misc"
+					}
+
+					if e.ReturnVal != 0 {
+						if c.showCategory {
+							eventStr = fmt.Sprintf("[%d][%s] %s: %s (retval=%d)",
+								e.Pid, category, e.SyscallName, e.Path, e.ReturnVal)
+						} else {
+							eventStr = fmt.Sprintf("[%d] %s: %s (retval=%d)",
+								e.Pid, e.SyscallName, e.Path, e.ReturnVal)
+						}
+					} else {
+						if c.showCategory {
+							eventStr = fmt.Sprintf("[%d][%s] %s: %s",
+								e.Pid, category, e.SyscallName, e.Path)
+						} else {
+							eventStr = fmt.Sprintf("[%d] %s: %s",
+								e.Pid, e.SyscallName, e.Path)
+						}
+					}
+				} else {
+					// More concise format
+					if strings.HasSuffix(e.SyscallName, "-return") {
+						eventStr = fmt.Sprintf("└─ %s → %s",
+							strings.TrimSuffix(e.SyscallName, "-return"), e.Path)
+					} else {
+						eventStr = fmt.Sprintf("┌─ %s: %s", e.SyscallName, e.Path)
+					}
+				}
+
+				fmt.Fprintln(os.Stdout, eventStr)
+			}
+		}
+	}()
+
+	<-tracer.Wait()
+
+	// Wait for tracer to finish, but also monitor the context
+	select {
+	case <-eventsDone:
+		fmt.Fprintf(os.Stderr, "DEBUG: Events channel closed, exiting event processor\n")
+	case <-ctx.Done():
+		// Context was canceled
+		fmt.Fprintf(os.Stderr, "DEBUG: Context canceled, stopping tracer\n")
+		tracer.Stop()
+	}
+
+	// Print summary if requested
+	if c.summarize {
+		duration := time.Since(startTime)
+
+		fmt.Fprintf(os.Stdout, "\n=== Summary ===\n")
+		fmt.Fprintf(os.Stdout, "Command completed in: %v\n", duration)
+
+		// Print top syscalls by frequency
+		fmt.Fprintf(os.Stdout, "\nTop syscalls:\n")
+		type syscallCount struct {
+			name  string
+			count int
+		}
+		var counts []syscallCount
+		for name, count := range stats {
+			if !strings.HasSuffix(name, "-return") {
+				counts = append(counts, syscallCount{name, count})
+			}
+		}
+		sort.Slice(counts, func(i, j int) bool {
+			return counts[i].count > counts[j].count
+		})
+
+		// Print top 10 or fewer
+		limit := 10
+		if len(counts) < limit {
+			limit = len(counts)
+		}
+		for i := 0; i < limit; i++ {
+			fmt.Fprintf(os.Stdout, "  %-15s: %d\n", counts[i].name, counts[i].count)
+		}
+
+		// Print categorized operations if requested
+		if c.showCategory {
+			printCategoryMap := func(title string, operations map[string]struct{}) {
+				if len(operations) > 0 {
+					fmt.Fprintf(os.Stdout, "\n%s (%d):\n", title, len(operations))
+					items := make([]string, 0, len(operations))
+					for op := range operations {
+						items = append(items, op)
+					}
+					sort.Strings(items)
+					for _, item := range items {
+						fmt.Fprintf(os.Stdout, "  - %s\n", item)
+					}
+				}
+			}
+
+			printCategoryMap("Memory operations", memoryOps)
+			printCategoryMap("Process operations", processOps)
+			printCategoryMap("Signal operations", signalOps)
+			printCategoryMap("Time operations", timeOps)
+			printCategoryMap("Security operations", securityOps)
+			printCategoryMap("IPC operations", ipcOps)
+		}
+
+		// Print file operations summary
+		if len(fileOps) > 0 {
+			fmt.Fprintf(os.Stdout, "\nFile operations (%d):\n", len(fileOps))
+			paths := make([]string, 0, len(fileOps))
+			for path := range fileOps {
+				paths = append(paths, path)
+			}
+			sort.Strings(paths)
+
+			// Print limited number of accessed files
+			limit := 15
+			if len(paths) < limit {
+				limit = len(paths)
+			}
+			for i := 0; i < limit; i++ {
+				fmt.Fprintf(os.Stdout, "  - %s\n", paths[i])
+			}
+			if len(paths) > limit {
+				fmt.Fprintf(os.Stdout, "  ... and %d more\n", len(paths)-limit)
+			}
+		}
+
+		// Print executed commands summary
+		if len(execOps) > 0 {
+			fmt.Fprintf(os.Stdout, "\nExecuted commands (%d):\n", len(execOps))
+			execs := make([]string, 0, len(execOps))
+			for path := range execOps {
+				execs = append(execs, path)
+			}
+			sort.Strings(execs)
+
+			for _, exec := range execs {
+				fmt.Fprintf(os.Stdout, "  - %s\n", exec)
+			}
+		}
+
+		// Print network operations summary
+		if len(networkOps) > 0 {
+			fmt.Fprintf(os.Stdout, "\nNetwork operations (%d):\n", len(networkOps))
+			nets := make([]string, 0, len(networkOps))
+			for op := range networkOps {
+				nets = append(nets, op)
+			}
+			sort.Strings(nets)
+
+			for _, net := range nets {
+				fmt.Fprintf(os.Stdout, "  - %s\n", net)
+			}
+		}
+	}
+
+	return nil
+}

--- a/tw/pkg/commands/ptrace/ptrace.go
+++ b/tw/pkg/commands/ptrace/ptrace.go
@@ -4,21 +4,21 @@
 package ptrace
 
 import (
+	"context"
 	"fmt"
 	"os"
+	"os/signal"
 	"sort"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/spf13/cobra"
 )
 
 type cfg struct {
-	verbose       bool
-	summarize     bool
-	showReturns   bool
 	filterSyscall string
-	showCategory  bool
+	showDetails   bool
 }
 
 func Command() *cobra.Command {
@@ -31,17 +31,14 @@ func Command() *cobra.Command {
 This tool shows file operations, network activity, and process execution in real-time.`,
 		Example: `  tw ptrace ls -la
   tw ptrace curl https://example.com
-  tw ptrace --verbose go build ./...`,
+  tw ptrace go build ./...`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return cfg.Run(cmd, args)
 		},
 	}
 
-	cmd.Flags().BoolVarP(&cfg.verbose, "verbose", "v", false, "Show more detailed syscall information")
-	cmd.Flags().BoolVarP(&cfg.summarize, "summarize", "s", true, "Show summary statistics at the end")
-	cmd.Flags().BoolVar(&cfg.showReturns, "show-returns", false, "Show syscall return values")
 	cmd.Flags().StringVar(&cfg.filterSyscall, "filter", "", "Only show syscalls matching this filter (comma-separated list)")
-	cmd.Flags().BoolVar(&cfg.showCategory, "categorize", false, "Group syscalls by category in summary")
+	cmd.Flags().BoolVar(&cfg.showDetails, "details", false, "Show detailed syscall information")
 
 	return cmd
 }
@@ -51,34 +48,25 @@ func (c *cfg) Run(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("no command specified")
 	}
 
-	ctx := cmd.Context()
+	ctx, cancel := context.WithCancel(cmd.Context())
+	defer cancel()
+
 	startTime := time.Now()
 
-	tracer, err := New(args, TracerOpts{
-		Args: args,
-	})
-	if err != nil {
-		return err
-	}
+	// Set up signal handling
+	signalCh := make(chan os.Signal, 1)
+	signal.Notify(signalCh, os.Interrupt, syscall.SIGTERM, syscall.SIGINT, syscall.SIGHUP)
 
-	fmt.Fprintf(os.Stdout, "Tracing command: %s\n", strings.Join(args, " "))
-	fmt.Fprintf(os.Stdout, "Press Ctrl+C to stop tracing\n\n")
-
-	if err := tracer.Start(ctx); err != nil {
-		return err
-	}
-
-	// Create statistics trackers
-	stats := make(map[string]int)
-	fileOps := make(map[string]struct{})
-	execOps := make(map[string]struct{})
-	networkOps := make(map[string]struct{})
-	memoryOps := make(map[string]struct{})
-	processOps := make(map[string]struct{})
-	signalOps := make(map[string]struct{})
-	timeOps := make(map[string]struct{})
-	securityOps := make(map[string]struct{})
-	ipcOps := make(map[string]struct{})
+	// Create a context that will be canceled when we receive a signal
+	go func() {
+		select {
+		case <-ctx.Done():
+			return
+		case <-signalCh:
+			// Cancel the context when we receive a signal
+			cancel()
+		}
+	}()
 
 	// Create syscall filter if specified
 	var filters []string
@@ -89,271 +77,92 @@ func (c *cfg) Run(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	// Set up a done channel to signal event processing completion
-	eventsDone := make(chan struct{})
-
-	go func() {
-		defer close(eventsDone)
-		fmt.Fprintf(os.Stderr, "DEBUG: Starting event processing goroutine\n")
-		eventCount := 0
-
-		for {
-			select {
-			case e, ok := <-tracer.Events():
-				if !ok {
-					// Channel closed, we're done
-					fmt.Fprintf(os.Stderr, "DEBUG: Events channel closed, exiting event processor\n")
-					return
-				}
-				eventCount++
-				fmt.Fprintf(os.Stderr, "DEBUG: Received event #%d: %s (pid=%d) type=%v\n",
-					eventCount, e.SyscallName, e.Pid, e.Type)
-
-				// Skip if filtering is enabled and this syscall doesn't match
-				if len(filters) > 0 {
-					match := false
-					for _, f := range filters {
-						if strings.Contains(e.SyscallName, f) {
-							match = true
-							break
-						}
-					}
-					if !match {
-						fmt.Fprintf(os.Stderr, "DEBUG: Filtering out %s (doesn't match filters)\n", e.SyscallName)
-						continue
-					}
-				}
-
-				// Skip return events if not requested
-				if !c.showReturns && strings.HasSuffix(e.SyscallName, "-return") {
-					fmt.Fprintf(os.Stderr, "DEBUG: Skipping return event %s\n", e.SyscallName)
-					continue
-				}
-
-				// Track statistics for summary
-				prevCount, _ := stats[e.SyscallName]
-				stats[e.SyscallName]++
-				fmt.Fprintf(os.Stderr, "DEBUG: Incremented stats for %s: %d -> %d\n",
-					e.SyscallName, prevCount, stats[e.SyscallName])
-
-				// Track operations by category
-				if !strings.HasSuffix(e.SyscallName, "-return") {
-					// Track file operations
-					if IsFileOpSyscall(e.Syscall) {
-						if e.Path != "" {
-							fileOps[e.Path] = struct{}{}
-							fmt.Fprintf(os.Stderr, "DEBUG: Added file operation: %s\n", e.Path)
-						} else {
-							fmt.Fprintf(os.Stderr, "DEBUG: File operation with empty path for %s\n", e.SyscallName)
-						}
-					} else if e.Type == EventExec {
-						if e.Path != "" {
-							execOps[e.Path] = struct{}{}
-							fmt.Fprintf(os.Stderr, "DEBUG: Added exec operation: %s\n", e.Path)
-						}
-					}
-
-					// Track network operations
-					if IsNetworkSyscall(e.Syscall) {
-						networkOps[e.Path] = struct{}{}
-						fmt.Fprintf(os.Stderr, "DEBUG: Added network operation: %s\n", e.Path)
-					}
-
-					// Track by category for extended classification
-					if IsMemorySyscall(e.Syscall) {
-						memoryOps[e.SyscallName] = struct{}{}
-					}
-					if IsProcessSyscall(e.Syscall) {
-						processOps[e.SyscallName] = struct{}{}
-					}
-					if IsSignalSyscall(e.Syscall) {
-						signalOps[e.SyscallName] = struct{}{}
-					}
-					if IsTimeSyscall(e.Syscall) {
-						timeOps[e.SyscallName] = struct{}{}
-					}
-					if IsSecuritySyscall(e.Syscall) {
-						securityOps[e.SyscallName] = struct{}{}
-					}
-					if IsIpcSyscall(e.Syscall) {
-						ipcOps[e.SyscallName] = struct{}{}
-					}
-				}
-
-				// Format and print event
-				var eventStr string
-
-				if c.verbose {
-					var category string
-					if IsFileOpSyscall(e.Syscall) {
-						category = "file"
-					} else if IsNetworkSyscall(e.Syscall) {
-						category = "net"
-					} else if IsExecSyscall(e.Syscall) {
-						category = "exec"
-					} else if IsMemorySyscall(e.Syscall) {
-						category = "mem"
-					} else if IsProcessSyscall(e.Syscall) {
-						category = "proc"
-					} else if IsSignalSyscall(e.Syscall) {
-						category = "sig"
-					} else if IsTimeSyscall(e.Syscall) {
-						category = "time"
-					} else if IsSecuritySyscall(e.Syscall) {
-						category = "sec"
-					} else if IsIpcSyscall(e.Syscall) {
-						category = "ipc"
-					} else {
-						category = "misc"
-					}
-
-					if e.ReturnVal != 0 {
-						if c.showCategory {
-							eventStr = fmt.Sprintf("[%d][%s] %s: %s (retval=%d)",
-								e.Pid, category, e.SyscallName, e.Path, e.ReturnVal)
-						} else {
-							eventStr = fmt.Sprintf("[%d] %s: %s (retval=%d)",
-								e.Pid, e.SyscallName, e.Path, e.ReturnVal)
-						}
-					} else {
-						if c.showCategory {
-							eventStr = fmt.Sprintf("[%d][%s] %s: %s",
-								e.Pid, category, e.SyscallName, e.Path)
-						} else {
-							eventStr = fmt.Sprintf("[%d] %s: %s",
-								e.Pid, e.SyscallName, e.Path)
-						}
-					}
-				} else {
-					// More concise format
-					if strings.HasSuffix(e.SyscallName, "-return") {
-						eventStr = fmt.Sprintf("└─ %s → %s",
-							strings.TrimSuffix(e.SyscallName, "-return"), e.Path)
-					} else {
-						eventStr = fmt.Sprintf("┌─ %s: %s", e.SyscallName, e.Path)
-					}
-				}
-
-				fmt.Fprintln(os.Stdout, eventStr)
-			}
-		}
-	}()
-
-	<-tracer.Wait()
-
-	// Wait for tracer to finish, but also monitor the context
-	select {
-	case <-eventsDone:
-		fmt.Fprintf(os.Stderr, "DEBUG: Events channel closed, exiting event processor\n")
-	case <-ctx.Done():
-		// Context was canceled
-		fmt.Fprintf(os.Stderr, "DEBUG: Context canceled, stopping tracer\n")
-		tracer.Stop()
+	// Create tracer instance
+	tracer, err := New(args, TracerOpts{
+		Args:        args,
+		Filter:      filters,
+		ShowDetails: c.showDetails,
+		Stdout:      os.Stdout,
+		Stderr:      os.Stderr,
+		SignalCh:    signalCh,
+	})
+	if err != nil {
+		return err
 	}
 
-	// Print summary if requested
-	if c.summarize {
-		duration := time.Since(startTime)
+	fmt.Fprintf(os.Stdout, "Tracing command: %s\n", strings.Join(args, " "))
+	fmt.Fprintf(os.Stdout, "Press Ctrl+C to stop tracing\n\n")
 
-		fmt.Fprintf(os.Stdout, "\n=== Summary ===\n")
-		fmt.Fprintf(os.Stdout, "Command completed in: %v\n", duration)
+	// Start the tracing process
+	if err := tracer.Start(ctx); err != nil {
+		return err
+	}
 
-		// Print top syscalls by frequency
-		fmt.Fprintf(os.Stdout, "\nTop syscalls:\n")
-		type syscallCount struct {
-			name  string
-			count int
-		}
-		var counts []syscallCount
-		for name, count := range stats {
-			if !strings.HasSuffix(name, "-return") {
-				counts = append(counts, syscallCount{name, count})
-			}
-		}
-		sort.Slice(counts, func(i, j int) bool {
-			return counts[i].count > counts[j].count
-		})
+	// Wait for the tracing to complete and get the report
+	report := tracer.Wait()
 
-		// Print top 10 or fewer
-		limit := 10
-		if len(counts) < limit {
-			limit = len(counts)
-		}
-		for i := 0; i < limit; i++ {
-			fmt.Fprintf(os.Stdout, "  %-15s: %d\n", counts[i].name, counts[i].count)
-		}
+	// Output the results
+	fmt.Fprintf(os.Stdout, "\nTracing completed in %s\n", time.Since(startTime))
+	fmt.Fprintf(os.Stdout, "Total syscalls: %d\n", report.TotalSyscalls)
 
-		// Print categorized operations if requested
-		if c.showCategory {
-			printCategoryMap := func(title string, operations map[string]struct{}) {
-				if len(operations) > 0 {
-					fmt.Fprintf(os.Stdout, "\n%s (%d):\n", title, len(operations))
-					items := make([]string, 0, len(operations))
-					for op := range operations {
-						items = append(items, op)
-					}
-					sort.Strings(items)
-					for _, item := range items {
-						fmt.Fprintf(os.Stdout, "  - %s\n", item)
-					}
-				}
-			}
+	// Show file activity if requested
+	if c.showDetails {
+		// Show file system activity
+		if len(report.FSActivity) > 0 {
+			fmt.Fprintf(os.Stdout, "\nFile system activity:\n")
+			fmt.Fprintf(os.Stdout, "%-50s %-10s %-10s\n", "Path", "Operations", "Processes")
+			fmt.Fprintf(os.Stdout, "%s\n", strings.Repeat("-", 72))
 
-			printCategoryMap("Memory operations", memoryOps)
-			printCategoryMap("Process operations", processOps)
-			printCategoryMap("Signal operations", signalOps)
-			printCategoryMap("Time operations", timeOps)
-			printCategoryMap("Security operations", securityOps)
-			printCategoryMap("IPC operations", ipcOps)
-		}
-
-		// Print file operations summary
-		if len(fileOps) > 0 {
-			fmt.Fprintf(os.Stdout, "\nFile operations (%d):\n", len(fileOps))
-			paths := make([]string, 0, len(fileOps))
-			for path := range fileOps {
+			// Sort paths for consistent output
+			paths := make([]string, 0, len(report.FSActivity))
+			for path := range report.FSActivity {
 				paths = append(paths, path)
 			}
 			sort.Strings(paths)
 
-			// Print limited number of accessed files
-			limit := 15
-			if len(paths) < limit {
-				limit = len(paths)
+			for _, path := range paths {
+				info := report.FSActivity[path]
+				fmt.Fprintf(os.Stdout, "%-50s %-10d %-10d\n",
+					truncatePath(path, 50),
+					info.OpsAll,
+					len(info.Pids))
 			}
+		} else {
+			fmt.Fprintf(os.Stdout, "\nNo file system activity detected\n")
+		}
+
+		// Show syscall statistics
+		if len(report.SyscallStats) > 0 {
+			fmt.Fprintf(os.Stdout, "\nSyscall statistics:\n")
+			fmt.Fprintf(os.Stdout, "%-20s %-10s\n", "Syscall", "Count")
+			fmt.Fprintf(os.Stdout, "%s\n", strings.Repeat("-", 32))
+
+			// Get syscall names and sort for consistent output
+			type syscallInfo struct {
+				num   uint32
+				count uint64
+				name  string
+			}
+
+			syscalls := make([]syscallInfo, 0, len(report.SyscallStats))
+			for num, count := range report.SyscallStats {
+				name := getSyscallName(num)
+				syscalls = append(syscalls, syscallInfo{num: num, count: count, name: name})
+			}
+
+			// Sort by count (descending)
+			sort.Slice(syscalls, func(i, j int) bool {
+				return syscalls[i].count > syscalls[j].count
+			})
+
+			// Show top 10 syscalls
+			limit := 10
+			if len(syscalls) < limit {
+				limit = len(syscalls)
+			}
+
 			for i := 0; i < limit; i++ {
-				fmt.Fprintf(os.Stdout, "  - %s\n", paths[i])
-			}
-			if len(paths) > limit {
-				fmt.Fprintf(os.Stdout, "  ... and %d more\n", len(paths)-limit)
-			}
-		}
-
-		// Print executed commands summary
-		if len(execOps) > 0 {
-			fmt.Fprintf(os.Stdout, "\nExecuted commands (%d):\n", len(execOps))
-			execs := make([]string, 0, len(execOps))
-			for path := range execOps {
-				execs = append(execs, path)
-			}
-			sort.Strings(execs)
-
-			for _, exec := range execs {
-				fmt.Fprintf(os.Stdout, "  - %s\n", exec)
-			}
-		}
-
-		// Print network operations summary
-		if len(networkOps) > 0 {
-			fmt.Fprintf(os.Stdout, "\nNetwork operations (%d):\n", len(networkOps))
-			nets := make([]string, 0, len(networkOps))
-			for op := range networkOps {
-				nets = append(nets, op)
-			}
-			sort.Strings(nets)
-
-			for _, net := range nets {
-				fmt.Fprintf(os.Stdout, "  - %s\n", net)
+				fmt.Fprintf(os.Stdout, "%-20s %-10d\n", syscalls[i].name, syscalls[i].count)
 			}
 		}
 	}

--- a/tw/pkg/commands/ptrace/syscalls_amd64.go
+++ b/tw/pkg/commands/ptrace/syscalls_amd64.go
@@ -1,0 +1,157 @@
+//go:build linux && amd64
+// +build linux,amd64
+
+package ptrace
+
+import (
+	"golang.org/x/sys/unix"
+)
+
+// AMD64Handler implements the ArchHandler interface for AMD64 architecture
+type AMD64Handler struct {
+	*BaseArchHandler
+}
+
+func (h *AMD64Handler) Name() string {
+	return "AMD64"
+}
+
+// Register accessor methods
+func (h *AMD64Handler) CallFirstParam(regs unix.PtraceRegs) uint64 {
+	return regs.Rdi
+}
+
+func (h *AMD64Handler) CallSecondParam(regs unix.PtraceRegs) uint64 {
+	return regs.Rsi
+}
+
+func (h *AMD64Handler) CallThirdParam(regs unix.PtraceRegs) uint64 {
+	return regs.Rdx
+}
+
+func (h *AMD64Handler) CallFourthParam(regs unix.PtraceRegs) uint64 {
+	return regs.R10
+}
+
+func (h *AMD64Handler) CallFifthParam(regs unix.PtraceRegs) uint64 {
+	return regs.R8
+}
+
+func (h *AMD64Handler) CallSixthParam(regs unix.PtraceRegs) uint64 {
+	return regs.R9
+}
+
+func (h *AMD64Handler) CallReturnValue(regs unix.PtraceRegs) uint64 {
+	return regs.Rax
+}
+
+// Get syscall number from registers
+func (h *AMD64Handler) GetSyscallNumber(regs unix.PtraceRegs) uint32 {
+	return uint32(regs.Orig_rax)
+}
+
+// AMD64 handler uses the base implementation for all syscall classifications
+// since we've populated the maps in the init function
+
+// AMD64-specific initialization
+func init() {
+	// Initialize the AMD64-specific architecture handler
+	base := NewBaseArchHandler()
+
+	// Register file operations
+	base.RegisterFileOp(
+		unix.SYS_OPEN, unix.SYS_OPENAT, unix.SYS_CLOSE, unix.SYS_READ, unix.SYS_WRITE,
+		unix.SYS_PREAD64, unix.SYS_PWRITE64, unix.SYS_LSEEK, unix.SYS_STAT, unix.SYS_FSTAT,
+		unix.SYS_LSTAT, unix.SYS_READLINK, unix.SYS_MKDIR, unix.SYS_RMDIR,
+		unix.SYS_UNLINK, unix.SYS_RENAME, unix.SYS_UNLINKAT, unix.SYS_MKDIRAT,
+		unix.SYS_RENAMEAT, unix.SYS_RENAMEAT2, unix.SYS_TRUNCATE, unix.SYS_FTRUNCATE,
+		unix.SYS_FSYNC, unix.SYS_FDATASYNC,
+	)
+
+	// Register network operations
+	base.RegisterNetworkOp(
+		unix.SYS_SOCKET, unix.SYS_CONNECT, unix.SYS_BIND, unix.SYS_LISTEN,
+		unix.SYS_ACCEPT, unix.SYS_ACCEPT4, unix.SYS_GETSOCKNAME, unix.SYS_GETPEERNAME,
+		unix.SYS_SOCKETPAIR, unix.SYS_SENDTO, unix.SYS_RECVFROM, unix.SYS_SHUTDOWN,
+		unix.SYS_SETSOCKOPT, unix.SYS_GETSOCKOPT, unix.SYS_SENDMSG, unix.SYS_RECVMSG,
+		unix.SYS_SENDMMSG, unix.SYS_RECVMMSG,
+	)
+
+	// Register exec operations
+	base.RegisterExecOp(
+		unix.SYS_EXECVE, unix.SYS_EXECVEAT,
+	)
+
+	// Register memory operations
+	base.RegisterMemoryOp(
+		unix.SYS_MMAP, unix.SYS_MUNMAP, unix.SYS_MPROTECT, unix.SYS_MREMAP,
+		unix.SYS_MSYNC, unix.SYS_MINCORE, unix.SYS_MADVISE, unix.SYS_BRK,
+		unix.SYS_MLOCK, unix.SYS_MUNLOCK, unix.SYS_MLOCKALL, unix.SYS_MUNLOCKALL,
+	)
+
+	// Register process operations
+	base.RegisterProcessOp(
+		unix.SYS_CLONE, unix.SYS_FORK, unix.SYS_VFORK, unix.SYS_GETPID,
+		unix.SYS_GETPPID, unix.SYS_GETUID, unix.SYS_GETEUID, unix.SYS_GETGID,
+		unix.SYS_GETEGID, unix.SYS_SETUID, unix.SYS_SETGID, unix.SYS_EXIT,
+		unix.SYS_EXIT_GROUP, unix.SYS_WAIT4, unix.SYS_SCHED_YIELD,
+		unix.SYS_CHDIR, unix.SYS_GETCWD, unix.SYS_CAPGET, unix.SYS_CAPSET,
+		unix.SYS_PRCTL, unix.SYS_SETPRIORITY, unix.SYS_GETPRIORITY,
+	)
+
+	// Register signal operations
+	base.RegisterSignalOp(
+		unix.SYS_KILL, unix.SYS_TKILL, unix.SYS_TGKILL, unix.SYS_RT_SIGACTION,
+		unix.SYS_RT_SIGPROCMASK, unix.SYS_RT_SIGRETURN, unix.SYS_RT_SIGPENDING,
+		unix.SYS_RT_SIGTIMEDWAIT, unix.SYS_RT_SIGQUEUEINFO, unix.SYS_RT_SIGSUSPEND,
+	)
+
+	// Register time operations
+	base.RegisterTimeOp(
+		unix.SYS_NANOSLEEP, unix.SYS_GETITIMER, unix.SYS_SETITIMER,
+		unix.SYS_TIMER_CREATE, unix.SYS_TIMER_GETTIME, unix.SYS_TIMER_SETTIME,
+		unix.SYS_TIMER_DELETE, unix.SYS_CLOCK_GETTIME, unix.SYS_CLOCK_SETTIME,
+		unix.SYS_CLOCK_GETRES, unix.SYS_CLOCK_NANOSLEEP, unix.SYS_TIME,
+	)
+
+	// Register security operations
+	base.RegisterSecurityOp(
+		unix.SYS_CAPGET, unix.SYS_CAPSET, unix.SYS_PRCTL,
+		unix.SYS_SECCOMP, unix.SYS_PTRACE,
+	)
+
+	// Register IPC operations
+	base.RegisterIpcOp(
+		unix.SYS_PIPE, unix.SYS_PIPE2, unix.SYS_FUTEX, unix.SYS_SOCKETPAIR,
+		unix.SYS_SHMGET, unix.SYS_SHMAT, unix.SYS_SHMCTL, unix.SYS_SHMDT,
+		unix.SYS_SEMGET, unix.SYS_SEMOP, unix.SYS_SEMCTL,
+		unix.SYS_MSGGET, unix.SYS_MSGSND, unix.SYS_MSGRCV, unix.SYS_MSGCTL,
+	)
+
+	archHandler = &AMD64Handler{BaseArchHandler: base}
+
+	// Add AMD64-specific syscalls to the map
+	syscallNames[unix.SYS_OPEN] = "open"
+
+	// Register AMD64-specific syscall processors
+	RegisterSyscallProcessor(&openSyscallProcessor{
+		baseSyscallProcessor: &baseSyscallProcessor{
+			num:         unix.SYS_OPEN,
+			name:        "open",
+			syscallType: OpenFileType,
+		},
+	})
+
+	RegisterSyscallProcessor(&statSyscallProcessor{
+		baseSyscallProcessor: &baseSyscallProcessor{
+			num:         unix.SYS_STAT,
+			name:        "stat",
+			syscallType: CheckFileType,
+		},
+	})
+}
+
+// AMD64 implementation of handleSyscall
+func (t *Tracer) handleSyscall(pid int) {
+	handleSyscall(t, pid)
+}

--- a/tw/pkg/commands/ptrace/syscalls_amd64.go
+++ b/tw/pkg/commands/ptrace/syscalls_amd64.go
@@ -4,154 +4,225 @@
 package ptrace
 
 import (
+	"syscall"
+
 	"golang.org/x/sys/unix"
 )
 
-// AMD64Handler implements the ArchHandler interface for AMD64 architecture
-type AMD64Handler struct {
-	*BaseArchHandler
-}
-
-func (h *AMD64Handler) Name() string {
-	return "AMD64"
-}
-
-// Register accessor methods
-func (h *AMD64Handler) CallFirstParam(regs unix.PtraceRegs) uint64 {
+// Get the first parameter from syscall registers (AMD64)
+func getFirstParam(regs syscall.PtraceRegs) uint64 {
 	return regs.Rdi
 }
 
-func (h *AMD64Handler) CallSecondParam(regs unix.PtraceRegs) uint64 {
+// Get the second parameter from syscall registers (AMD64)
+func getSecondParam(regs syscall.PtraceRegs) uint64 {
 	return regs.Rsi
 }
 
-func (h *AMD64Handler) CallThirdParam(regs unix.PtraceRegs) uint64 {
-	return regs.Rdx
+// Get syscall number from registers (AMD64)
+func getSyscallNumber(regs syscall.PtraceRegs) uint64 {
+	return regs.Orig_rax
 }
 
-func (h *AMD64Handler) CallFourthParam(regs unix.PtraceRegs) uint64 {
-	return regs.R10
-}
-
-func (h *AMD64Handler) CallFifthParam(regs unix.PtraceRegs) uint64 {
-	return regs.R8
-}
-
-func (h *AMD64Handler) CallSixthParam(regs unix.PtraceRegs) uint64 {
-	return regs.R9
-}
-
-func (h *AMD64Handler) CallReturnValue(regs unix.PtraceRegs) uint64 {
+// Get return value from registers (AMD64)
+func getReturnValue(regs syscall.PtraceRegs) uint64 {
 	return regs.Rax
 }
 
-// Get syscall number from registers
-func (h *AMD64Handler) GetSyscallNumber(regs unix.PtraceRegs) uint32 {
-	return uint32(regs.Orig_rax)
+// getSyscallName maps syscall numbers to names for AMD64
+func getSyscallName(num uint32) string {
+	if name, ok := syscallNames[num]; ok {
+		return name
+	}
+	return "syscall_" + itoa(int(num))
 }
 
-// AMD64 handler uses the base implementation for all syscall classifications
-// since we've populated the maps in the init function
-
-// AMD64-specific initialization
-func init() {
-	// Initialize the AMD64-specific architecture handler
-	base := NewBaseArchHandler()
-
-	// Register file operations
-	base.RegisterFileOp(
-		unix.SYS_OPEN, unix.SYS_OPENAT, unix.SYS_CLOSE, unix.SYS_READ, unix.SYS_WRITE,
-		unix.SYS_PREAD64, unix.SYS_PWRITE64, unix.SYS_LSEEK, unix.SYS_STAT, unix.SYS_FSTAT,
-		unix.SYS_LSTAT, unix.SYS_READLINK, unix.SYS_MKDIR, unix.SYS_RMDIR,
-		unix.SYS_UNLINK, unix.SYS_RENAME, unix.SYS_UNLINKAT, unix.SYS_MKDIRAT,
-		unix.SYS_RENAMEAT, unix.SYS_RENAMEAT2, unix.SYS_TRUNCATE, unix.SYS_FTRUNCATE,
-		unix.SYS_FSYNC, unix.SYS_FDATASYNC,
-	)
-
-	// Register network operations
-	base.RegisterNetworkOp(
-		unix.SYS_SOCKET, unix.SYS_CONNECT, unix.SYS_BIND, unix.SYS_LISTEN,
-		unix.SYS_ACCEPT, unix.SYS_ACCEPT4, unix.SYS_GETSOCKNAME, unix.SYS_GETPEERNAME,
-		unix.SYS_SOCKETPAIR, unix.SYS_SENDTO, unix.SYS_RECVFROM, unix.SYS_SHUTDOWN,
-		unix.SYS_SETSOCKOPT, unix.SYS_GETSOCKOPT, unix.SYS_SENDMSG, unix.SYS_RECVMSG,
-		unix.SYS_SENDMMSG, unix.SYS_RECVMMSG,
-	)
-
-	// Register exec operations
-	base.RegisterExecOp(
-		unix.SYS_EXECVE, unix.SYS_EXECVEAT,
-	)
-
-	// Register memory operations
-	base.RegisterMemoryOp(
-		unix.SYS_MMAP, unix.SYS_MUNMAP, unix.SYS_MPROTECT, unix.SYS_MREMAP,
-		unix.SYS_MSYNC, unix.SYS_MINCORE, unix.SYS_MADVISE, unix.SYS_BRK,
-		unix.SYS_MLOCK, unix.SYS_MUNLOCK, unix.SYS_MLOCKALL, unix.SYS_MUNLOCKALL,
-	)
-
-	// Register process operations
-	base.RegisterProcessOp(
-		unix.SYS_CLONE, unix.SYS_FORK, unix.SYS_VFORK, unix.SYS_GETPID,
-		unix.SYS_GETPPID, unix.SYS_GETUID, unix.SYS_GETEUID, unix.SYS_GETGID,
-		unix.SYS_GETEGID, unix.SYS_SETUID, unix.SYS_SETGID, unix.SYS_EXIT,
-		unix.SYS_EXIT_GROUP, unix.SYS_WAIT4, unix.SYS_SCHED_YIELD,
-		unix.SYS_CHDIR, unix.SYS_GETCWD, unix.SYS_CAPGET, unix.SYS_CAPSET,
-		unix.SYS_PRCTL, unix.SYS_SETPRIORITY, unix.SYS_GETPRIORITY,
-	)
-
-	// Register signal operations
-	base.RegisterSignalOp(
-		unix.SYS_KILL, unix.SYS_TKILL, unix.SYS_TGKILL, unix.SYS_RT_SIGACTION,
-		unix.SYS_RT_SIGPROCMASK, unix.SYS_RT_SIGRETURN, unix.SYS_RT_SIGPENDING,
-		unix.SYS_RT_SIGTIMEDWAIT, unix.SYS_RT_SIGQUEUEINFO, unix.SYS_RT_SIGSUSPEND,
-	)
-
-	// Register time operations
-	base.RegisterTimeOp(
-		unix.SYS_NANOSLEEP, unix.SYS_GETITIMER, unix.SYS_SETITIMER,
-		unix.SYS_TIMER_CREATE, unix.SYS_TIMER_GETTIME, unix.SYS_TIMER_SETTIME,
-		unix.SYS_TIMER_DELETE, unix.SYS_CLOCK_GETTIME, unix.SYS_CLOCK_SETTIME,
-		unix.SYS_CLOCK_GETRES, unix.SYS_CLOCK_NANOSLEEP, unix.SYS_TIME,
-	)
-
-	// Register security operations
-	base.RegisterSecurityOp(
-		unix.SYS_CAPGET, unix.SYS_CAPSET, unix.SYS_PRCTL,
-		unix.SYS_SECCOMP, unix.SYS_PTRACE,
-	)
-
-	// Register IPC operations
-	base.RegisterIpcOp(
-		unix.SYS_PIPE, unix.SYS_PIPE2, unix.SYS_FUTEX, unix.SYS_SOCKETPAIR,
-		unix.SYS_SHMGET, unix.SYS_SHMAT, unix.SYS_SHMCTL, unix.SYS_SHMDT,
-		unix.SYS_SEMGET, unix.SYS_SEMOP, unix.SYS_SEMCTL,
-		unix.SYS_MSGGET, unix.SYS_MSGSND, unix.SYS_MSGRCV, unix.SYS_MSGCTL,
-	)
-
-	archHandler = &AMD64Handler{BaseArchHandler: base}
-
-	// Add AMD64-specific syscalls to the map
-	syscallNames[unix.SYS_OPEN] = "open"
-
-	// Register AMD64-specific syscall processors
-	RegisterSyscallProcessor(&openSyscallProcessor{
-		baseSyscallProcessor: &baseSyscallProcessor{
-			num:         unix.SYS_OPEN,
-			name:        "open",
-			syscallType: OpenFileType,
-		},
-	})
-
-	RegisterSyscallProcessor(&statSyscallProcessor{
-		baseSyscallProcessor: &baseSyscallProcessor{
-			num:         unix.SYS_STAT,
-			name:        "stat",
-			syscallType: CheckFileType,
-		},
-	})
+// itoa is a simple function to convert int to string
+func itoa(val int) string {
+	if val < 0 {
+		return "-" + uitoa(uint(-val))
+	}
+	return uitoa(uint(val))
 }
 
-// AMD64 implementation of handleSyscall
-func (t *Tracer) handleSyscall(pid int) {
-	handleSyscall(t, pid)
+// uitoa converts an unsigned integer to a string
+func uitoa(val uint) string {
+	var buf [32]byte // big enough for int64
+	i := len(buf) - 1
+	for val >= 10 {
+		q := val / 10
+		buf[i] = byte('0' + val - q*10)
+		i--
+		val = q
+	}
+	buf[i] = byte('0' + val)
+	return string(buf[i:])
+}
+
+// registerSyscallHandlers registers architecture-specific syscall handlers
+func (t *Tracer) registerHandlers() {
+	// File check syscalls
+	t.registerFileCheckHandlers()
+
+	// File open syscalls
+	t.registerFileOpenHandlers()
+
+	// Exec syscalls
+	t.registerExecHandlers()
+}
+
+func (t *Tracer) registerFileCheckHandlers() {
+	// stat(const char *pathname, struct stat *statbuf)
+	t.handlers[unix.SYS_STAT] = NewFileCheckHandler(unix.SYS_STAT, "stat", 1)
+
+	// fstat(int fd, struct stat *statbuf)
+	t.handlers[unix.SYS_FSTAT] = NewFileCheckHandler(unix.SYS_FSTAT, "fstat", 0)
+
+	// lstat(const char *pathname, struct stat *statbuf)
+	t.handlers[unix.SYS_LSTAT] = NewFileCheckHandler(unix.SYS_LSTAT, "lstat", 1)
+
+	// access(const char *pathname, int mode)
+	t.handlers[unix.SYS_ACCESS] = NewFileCheckHandler(unix.SYS_ACCESS, "access", 1)
+
+	// newfstatat/fstatat(int dirfd, const char *pathname, struct stat *statbuf, int flags)
+	t.handlers[unix.SYS_NEWFSTATAT] = NewFileCheckHandler(unix.SYS_NEWFSTATAT, "newfstatat", 2)
+
+	// faccessat(int dirfd, const char *pathname, int mode, int flags)
+	t.handlers[unix.SYS_FACCESSAT] = NewFileCheckHandler(unix.SYS_FACCESSAT, "faccessat", 2)
+
+	// statx(int dirfd, const char *pathname, int flags, unsigned int mask, struct statx *statxbuf)
+	t.handlers[unix.SYS_STATX] = NewFileCheckHandler(unix.SYS_STATX, "statx", 2)
+}
+
+func (t *Tracer) registerFileOpenHandlers() {
+	// open(const char *pathname, int flags, mode_t mode)
+	t.handlers[unix.SYS_OPEN] = NewFileOpenHandler(unix.SYS_OPEN, "open", 1)
+
+	// openat(int dirfd, const char *pathname, int flags, mode_t mode)
+	t.handlers[unix.SYS_OPENAT] = NewFileOpenHandler(unix.SYS_OPENAT, "openat", 2)
+
+	// readlink(const char *pathname, char *buf, size_t bufsiz)
+	t.handlers[unix.SYS_READLINK] = NewFileOpenHandler(unix.SYS_READLINK, "readlink", 1)
+
+	// readlinkat(int dirfd, const char *pathname, char *buf, size_t bufsiz)
+	t.handlers[unix.SYS_READLINKAT] = NewFileOpenHandler(unix.SYS_READLINKAT, "readlinkat", 2)
+}
+
+func (t *Tracer) registerExecHandlers() {
+	// execve(const char *pathname, char *const argv[], char *const envp[])
+	t.handlers[unix.SYS_EXECVE] = NewExecHandler(unix.SYS_EXECVE, "execve", 1)
+
+	// execveat(int dirfd, const char *pathname, char *const argv[], char *const envp[], int flags)
+	t.handlers[unix.SYS_EXECVEAT] = NewExecHandler(unix.SYS_EXECVEAT, "execveat", 2)
+}
+
+// Initialize syscallNames map using unix constants
+var syscallNames = map[uint32]string{
+	unix.SYS_READ:           "read",
+	unix.SYS_WRITE:          "write",
+	unix.SYS_OPEN:           "open",
+	unix.SYS_CLOSE:          "close",
+	unix.SYS_STAT:           "stat",
+	unix.SYS_FSTAT:          "fstat",
+	unix.SYS_LSTAT:          "lstat",
+	unix.SYS_POLL:           "poll",
+	unix.SYS_LSEEK:          "lseek",
+	unix.SYS_MMAP:           "mmap",
+	unix.SYS_MPROTECT:       "mprotect",
+	unix.SYS_MUNMAP:         "munmap",
+	unix.SYS_BRK:            "brk",
+	unix.SYS_RT_SIGACTION:   "rt_sigaction",
+	unix.SYS_RT_SIGPROCMASK: "rt_sigprocmask",
+	unix.SYS_RT_SIGRETURN:   "rt_sigreturn",
+	unix.SYS_IOCTL:          "ioctl",
+	unix.SYS_PREAD64:        "pread64",
+	unix.SYS_PWRITE64:       "pwrite64",
+	unix.SYS_READV:          "readv",
+	unix.SYS_WRITEV:         "writev",
+	unix.SYS_ACCESS:         "access",
+	unix.SYS_PIPE:           "pipe",
+	unix.SYS_SELECT:         "select",
+	unix.SYS_SCHED_YIELD:    "sched_yield",
+	unix.SYS_MREMAP:         "mremap",
+	unix.SYS_MSYNC:          "msync",
+	unix.SYS_MINCORE:        "mincore",
+	unix.SYS_MADVISE:        "madvise",
+	unix.SYS_SHMGET:         "shmget",
+	unix.SYS_SHMAT:          "shmat",
+	unix.SYS_SHMCTL:         "shmctl",
+	unix.SYS_DUP:            "dup",
+	unix.SYS_DUP2:           "dup2",
+	unix.SYS_PAUSE:          "pause",
+	unix.SYS_NANOSLEEP:      "nanosleep",
+	unix.SYS_GETITIMER:      "getitimer",
+	unix.SYS_ALARM:          "alarm",
+	unix.SYS_SETITIMER:      "setitimer",
+	unix.SYS_GETPID:         "getpid",
+	unix.SYS_SENDFILE:       "sendfile",
+	unix.SYS_SOCKET:         "socket",
+	unix.SYS_CONNECT:        "connect",
+	unix.SYS_ACCEPT:         "accept",
+	unix.SYS_SENDTO:         "sendto",
+	unix.SYS_RECVFROM:       "recvfrom",
+	unix.SYS_SENDMSG:        "sendmsg",
+	unix.SYS_RECVMSG:        "recvmsg",
+	unix.SYS_SHUTDOWN:       "shutdown",
+	unix.SYS_BIND:           "bind",
+	unix.SYS_LISTEN:         "listen",
+	unix.SYS_GETSOCKNAME:    "getsockname",
+	unix.SYS_GETPEERNAME:    "getpeername",
+	unix.SYS_SOCKETPAIR:     "socketpair",
+	unix.SYS_SETSOCKOPT:     "setsockopt",
+	unix.SYS_GETSOCKOPT:     "getsockopt",
+	unix.SYS_CLONE:          "clone",
+	unix.SYS_FORK:           "fork",
+	unix.SYS_VFORK:          "vfork",
+	unix.SYS_EXECVE:         "execve",
+	unix.SYS_EXIT:           "exit",
+	unix.SYS_WAIT4:          "wait4",
+	unix.SYS_KILL:           "kill",
+	unix.SYS_UNAME:          "uname",
+	unix.SYS_SEMGET:         "semget",
+	unix.SYS_SEMOP:          "semop",
+	unix.SYS_SEMCTL:         "semctl",
+	unix.SYS_SHMDT:          "shmdt",
+	unix.SYS_MSGGET:         "msgget",
+	unix.SYS_MSGSND:         "msgsnd",
+	unix.SYS_MSGRCV:         "msgrcv",
+	unix.SYS_MSGCTL:         "msgctl",
+	unix.SYS_FCNTL:          "fcntl",
+	unix.SYS_FLOCK:          "flock",
+	unix.SYS_FSYNC:          "fsync",
+	unix.SYS_FDATASYNC:      "fdatasync",
+	unix.SYS_TRUNCATE:       "truncate",
+	unix.SYS_FTRUNCATE:      "ftruncate",
+	unix.SYS_GETDENTS:       "getdents",
+	unix.SYS_GETCWD:         "getcwd",
+	unix.SYS_CHDIR:          "chdir",
+	unix.SYS_FCHDIR:         "fchdir",
+	unix.SYS_RENAME:         "rename",
+	unix.SYS_MKDIR:          "mkdir",
+	unix.SYS_RMDIR:          "rmdir",
+	unix.SYS_CREAT:          "creat",
+	unix.SYS_LINK:           "link",
+	unix.SYS_UNLINK:         "unlink",
+	unix.SYS_SYMLINK:        "symlink",
+	unix.SYS_READLINK:       "readlink",
+	unix.SYS_CHMOD:          "chmod",
+	unix.SYS_FCHMOD:         "fchmod",
+	unix.SYS_CHOWN:          "chown",
+	unix.SYS_FCHOWN:         "fchown",
+	unix.SYS_LCHOWN:         "lchown",
+	unix.SYS_UMASK:          "umask",
+	unix.SYS_GETTIMEOFDAY:   "gettimeofday",
+	unix.SYS_GETRLIMIT:      "getrlimit",
+	unix.SYS_GETRUSAGE:      "getrusage",
+	unix.SYS_SYSINFO:        "sysinfo",
+	unix.SYS_TIMES:          "times",
+	unix.SYS_OPENAT:         "openat",
+	unix.SYS_NEWFSTATAT:     "newfstatat",
+	unix.SYS_READLINKAT:     "readlinkat",
+	unix.SYS_FACCESSAT:      "faccessat",
+	unix.SYS_EXECVEAT:       "execveat",
+	unix.SYS_STATX:          "statx",
 }

--- a/tw/pkg/commands/ptrace/syscalls_arm64.go
+++ b/tw/pkg/commands/ptrace/syscalls_arm64.go
@@ -4,140 +4,212 @@
 package ptrace
 
 import (
-	"fmt"
-	"os"
+	"syscall"
 
 	"golang.org/x/sys/unix"
 )
 
-// ARM64Handler implements the ArchHandler interface for ARM64 architecture
-type ARM64Handler struct {
-	*BaseArchHandler
+// Get the first parameter from syscall registers (ARM64)
+func getFirstParam(regs syscall.PtraceRegs) uint64 {
+	return regs.Regs[0]
 }
 
-func (h *ARM64Handler) Name() string {
-	return "ARM64"
+// Get the second parameter from syscall registers (ARM64)
+func getSecondParam(regs syscall.PtraceRegs) uint64 {
+	return regs.Regs[1]
 }
 
-// Register accessor methods
-func (h *ARM64Handler) CallFirstParam(regs unix.PtraceRegs) uint64 {
-	return uint64(regs.Regs[0])
+// Get syscall number from registers (ARM64)
+func getSyscallNumber(regs syscall.PtraceRegs) uint64 {
+	return regs.Regs[8]
 }
 
-func (h *ARM64Handler) CallSecondParam(regs unix.PtraceRegs) uint64 {
-	return uint64(regs.Regs[1])
+// Get return value from registers (ARM64)
+func getReturnValue(regs syscall.PtraceRegs) uint64 {
+	return regs.Regs[0]
 }
 
-func (h *ARM64Handler) CallThirdParam(regs unix.PtraceRegs) uint64 {
-	return uint64(regs.Regs[2])
+// getSyscallName maps syscall numbers to names for ARM64
+func getSyscallName(num uint32) string {
+	if name, ok := syscallNames[num]; ok {
+		return name
+	}
+	return "syscall_" + itoa(int(num))
 }
 
-func (h *ARM64Handler) CallFourthParam(regs unix.PtraceRegs) uint64 {
-	return uint64(regs.Regs[3])
+// itoa is a simple function to convert int to string
+func itoa(val int) string {
+	if val < 0 {
+		return "-" + uitoa(uint(-val))
+	}
+	return uitoa(uint(val))
 }
 
-func (h *ARM64Handler) CallFifthParam(regs unix.PtraceRegs) uint64 {
-	return uint64(regs.Regs[4])
+// uitoa converts an unsigned integer to a string
+func uitoa(val uint) string {
+	var buf [32]byte // big enough for int64
+	i := len(buf) - 1
+	for val >= 10 {
+		q := val / 10
+		buf[i] = byte('0' + val - q*10)
+		i--
+		val = q
+	}
+	buf[i] = byte('0' + val)
+	return string(buf[i:])
 }
 
-func (h *ARM64Handler) CallSixthParam(regs unix.PtraceRegs) uint64 {
-	return uint64(regs.Regs[5])
+// registerSyscallHandlers registers architecture-specific syscall handlers
+func (t *Tracer) registerHandlers() {
+	// File check syscalls
+	t.registerFileCheckHandlers()
+
+	// File open syscalls
+	t.registerFileOpenHandlers()
+
+	// Exec syscalls
+	t.registerExecHandlers()
 }
 
-func (h *ARM64Handler) CallReturnValue(regs unix.PtraceRegs) uint64 {
-	return uint64(regs.Regs[0])
+func (t *Tracer) registerFileCheckHandlers() {
+	// stat(const char *pathname, struct stat *statbuf)
+	t.handlers[unix.SYS_STATFS] = NewFileCheckHandler(unix.SYS_STATFS, "stat", 1)
+
+	// fstat(int fd, struct stat *statbuf)
+	t.handlers[unix.SYS_FSTAT] = NewFileCheckHandler(unix.SYS_FSTAT, "fstat", 0)
+
+	t.handlers[unix.SYS_OPENAT] = NewFileCheckHandler(unix.SYS_OPENAT, "openat", 2)
+	t.handlers[unix.SYS_OPENAT2] = NewFileCheckHandler(unix.SYS_OPENAT2, "openat2", 2)
+
+	// newfstatat/fstatat(int dirfd, const char *pathname, struct stat *statbuf, int flags)
+	t.handlers[unix.SYS_NEWFSTATAT] = NewFileCheckHandler(unix.SYS_NEWFSTATAT, "newfstatat", 2)
+
+	// faccessat(int dirfd, const char *pathname, int mode, int flags)
+	t.handlers[unix.SYS_FACCESSAT] = NewFileCheckHandler(unix.SYS_FACCESSAT, "faccessat", 2)
+
+	// statx(int dirfd, const char *pathname, int flags, unsigned int mask, struct statx *statxbuf)
+	t.handlers[unix.SYS_STATX] = NewFileCheckHandler(unix.SYS_STATX, "statx", 2)
 }
 
-// Get syscall number from registers for ARM64
-func (h *ARM64Handler) GetSyscallNumber(regs unix.PtraceRegs) uint32 {
-	return uint32(regs.Regs[8])
+func (t *Tracer) registerFileOpenHandlers() {
+	// openat(int dirfd, const char *pathname, int flags, mode_t mode)
+	// Note: In ARM64, open is implemented via openat with AT_FDCWD
+	t.handlers[unix.SYS_OPENAT] = NewFileOpenHandler(unix.SYS_OPENAT, "openat", 2)
+
+	// readlinkat(int dirfd, const char *pathname, char *buf, size_t bufsiz)
+	// Note: In ARM64, readlink is implemented via readlinkat with AT_FDCWD
+	t.handlers[unix.SYS_READLINKAT] = NewFileOpenHandler(unix.SYS_READLINKAT, "readlinkat", 2)
 }
 
-// ARM64 handler uses the base implementation for all syscall classifications
-// since we've populated the maps in the init function
+func (t *Tracer) registerExecHandlers() {
+	// execve(const char *pathname, char *const argv[], char *const envp[])
+	t.handlers[unix.SYS_EXECVE] = NewExecHandler(unix.SYS_EXECVE, "execve", 1)
 
-// ARM64-specific initialization
-func init() {
-	// Initialize the ARM64-specific architecture handler
-	base := NewBaseArchHandler()
-
-	// Register file operations
-	base.RegisterFileOp(
-		unix.SYS_OPENAT, unix.SYS_CLOSE, unix.SYS_READ, unix.SYS_WRITE,
-		unix.SYS_PREAD64, unix.SYS_PWRITE64, unix.SYS_LSEEK, unix.SYS_FSTAT,
-		unix.SYS_UNLINKAT, unix.SYS_MKDIRAT, unix.SYS_RENAMEAT, unix.SYS_RENAMEAT2,
-		unix.SYS_READLINKAT, unix.SYS_TRUNCATE, unix.SYS_FTRUNCATE, unix.SYS_FSYNC,
-		unix.SYS_FDATASYNC,
-	)
-
-	// Register network operations
-	base.RegisterNetworkOp(
-		unix.SYS_SOCKET, unix.SYS_CONNECT, unix.SYS_BIND, unix.SYS_LISTEN,
-		unix.SYS_ACCEPT, unix.SYS_ACCEPT4, unix.SYS_GETSOCKNAME, unix.SYS_GETPEERNAME,
-		unix.SYS_SOCKETPAIR, unix.SYS_SENDTO, unix.SYS_RECVFROM, unix.SYS_SHUTDOWN,
-		unix.SYS_SETSOCKOPT, unix.SYS_GETSOCKOPT, unix.SYS_SENDMSG, unix.SYS_RECVMSG,
-	)
-
-	// Register exec operations
-	base.RegisterExecOp(
-		unix.SYS_EXECVE, unix.SYS_EXECVEAT,
-	)
-
-	// Register memory operations
-	base.RegisterMemoryOp(
-		unix.SYS_MMAP, unix.SYS_MUNMAP, unix.SYS_MPROTECT, unix.SYS_MREMAP,
-		unix.SYS_MSYNC, unix.SYS_MINCORE, unix.SYS_MADVISE, unix.SYS_BRK,
-		unix.SYS_MLOCK, unix.SYS_MUNLOCK, unix.SYS_MLOCKALL, unix.SYS_MUNLOCKALL,
-	)
-
-	// Register process operations
-	base.RegisterProcessOp(
-		unix.SYS_CLONE, unix.SYS_GETPID, unix.SYS_GETPPID, unix.SYS_GETUID,
-		unix.SYS_GETEUID, unix.SYS_GETGID, unix.SYS_GETEGID, unix.SYS_SETUID,
-		unix.SYS_SETGID, unix.SYS_EXIT, unix.SYS_EXIT_GROUP, unix.SYS_WAIT4,
-		unix.SYS_SCHED_YIELD, unix.SYS_CHDIR, unix.SYS_GETCWD, unix.SYS_CAPGET,
-		unix.SYS_CAPSET, unix.SYS_PRCTL, unix.SYS_SETPRIORITY, unix.SYS_GETPRIORITY,
-	)
-
-	// Register signal operations
-	base.RegisterSignalOp(
-		unix.SYS_KILL, unix.SYS_TKILL, unix.SYS_TGKILL, unix.SYS_RT_SIGACTION,
-		unix.SYS_RT_SIGPROCMASK, unix.SYS_RT_SIGRETURN, unix.SYS_RT_SIGPENDING,
-		unix.SYS_RT_SIGTIMEDWAIT, unix.SYS_RT_SIGQUEUEINFO, unix.SYS_RT_SIGSUSPEND,
-	)
-
-	// Register time operations
-	base.RegisterTimeOp(
-		unix.SYS_NANOSLEEP, unix.SYS_GETITIMER, unix.SYS_SETITIMER,
-		unix.SYS_TIMER_CREATE, unix.SYS_TIMER_GETTIME, unix.SYS_TIMER_SETTIME,
-		unix.SYS_TIMER_DELETE, unix.SYS_CLOCK_GETTIME, unix.SYS_CLOCK_SETTIME,
-		unix.SYS_CLOCK_GETRES, unix.SYS_CLOCK_NANOSLEEP,
-	)
-
-	// Register security operations
-	base.RegisterSecurityOp(
-		unix.SYS_CAPGET, unix.SYS_CAPSET, unix.SYS_PRCTL,
-		unix.SYS_SECCOMP, unix.SYS_PTRACE,
-	)
-
-	// Register IPC operations
-	base.RegisterIpcOp(
-		unix.SYS_PIPE2, unix.SYS_FUTEX, unix.SYS_SOCKETPAIR,
-		unix.SYS_SHMGET, unix.SYS_SHMAT, unix.SYS_SHMCTL, unix.SYS_SHMDT,
-		unix.SYS_SEMGET, unix.SYS_SEMOP, unix.SYS_SEMCTL,
-		unix.SYS_MSGGET, unix.SYS_MSGSND, unix.SYS_MSGRCV, unix.SYS_MSGCTL,
-	)
-
-	archHandler = &ARM64Handler{BaseArchHandler: base}
-
-	// Debug: Print OpenAT syscall number
-	fmt.Fprintf(os.Stdout, "ARM64 init: unix.SYS_OPENAT=%d\n", unix.SYS_OPENAT)
-
-	// Let's not register openat handler here - it's registered in the common code
-	// and we're possibly registering it twice with different handlers
+	// execveat(int dirfd, const char *pathname, char *const argv[], char *const envp[], int flags)
+	t.handlers[unix.SYS_EXECVEAT] = NewExecHandler(unix.SYS_EXECVEAT, "execveat", 2)
 }
 
-// ARM64 implementation of handleSyscall
-func (t *Tracer) handleSyscall(pid int) {
-	handleSyscall(t, pid)
+// Initialize syscallNames map using unix constants
+var syscallNames = map[uint32]string{
+	unix.SYS_READ:  "read",
+	unix.SYS_WRITE: "write",
+	// Note: ARM64 doesn't have SYS_OPEN, it uses openat with AT_FDCWD
+	unix.SYS_CLOSE: "close",
+	// unix.SYS_STAT:           "stat",
+	unix.SYS_FSTAT: "fstat",
+	// unix.SYS_LSTAT:          "lstat",
+	unix.SYS_PPOLL:          "ppoll",
+	unix.SYS_LSEEK:          "lseek",
+	unix.SYS_MMAP:           "mmap",
+	unix.SYS_MPROTECT:       "mprotect",
+	unix.SYS_MUNMAP:         "munmap",
+	unix.SYS_BRK:            "brk",
+	unix.SYS_RT_SIGACTION:   "rt_sigaction",
+	unix.SYS_RT_SIGPROCMASK: "rt_sigprocmask",
+	unix.SYS_RT_SIGRETURN:   "rt_sigreturn",
+	unix.SYS_IOCTL:          "ioctl",
+	unix.SYS_PREAD64:        "pread64",
+	unix.SYS_PWRITE64:       "pwrite64",
+	unix.SYS_READV:          "readv",
+	unix.SYS_WRITEV:         "writev",
+	unix.SYS_FACCESSAT:      "faccessat",
+	unix.SYS_FACCESSAT2:     "faccessat2",
+	unix.SYS_PIPE2:          "pipe2",
+	unix.SYS_SCHED_YIELD:    "sched_yield",
+	unix.SYS_MREMAP:         "mremap",
+	unix.SYS_MSYNC:          "msync",
+	unix.SYS_MINCORE:        "mincore",
+	unix.SYS_MADVISE:        "madvise",
+	unix.SYS_SHMGET:         "shmget",
+	unix.SYS_SHMAT:          "shmat",
+	unix.SYS_SHMCTL:         "shmctl",
+	unix.SYS_DUP:            "dup",
+	unix.SYS_DUP3:           "dup3",
+	unix.SYS_NANOSLEEP:      "nanosleep",
+	unix.SYS_GETITIMER:      "getitimer",
+	unix.SYS_SETITIMER:      "setitimer",
+	unix.SYS_GETPID:         "getpid",
+	unix.SYS_SENDFILE:       "sendfile",
+	unix.SYS_SOCKET:         "socket",
+	unix.SYS_CONNECT:        "connect",
+	unix.SYS_ACCEPT:         "accept",
+	unix.SYS_SENDTO:         "sendto",
+	unix.SYS_RECVFROM:       "recvfrom",
+	unix.SYS_SENDMSG:        "sendmsg",
+	unix.SYS_RECVMSG:        "recvmsg",
+	unix.SYS_SHUTDOWN:       "shutdown",
+	unix.SYS_BIND:           "bind",
+	unix.SYS_LISTEN:         "listen",
+	unix.SYS_GETSOCKNAME:    "getsockname",
+	unix.SYS_GETPEERNAME:    "getpeername",
+	unix.SYS_SOCKETPAIR:     "socketpair",
+	unix.SYS_SETSOCKOPT:     "setsockopt",
+	unix.SYS_GETSOCKOPT:     "getsockopt",
+	unix.SYS_CLONE:          "clone",
+	unix.SYS_EXECVE:         "execve",
+	unix.SYS_EXIT:           "exit",
+	unix.SYS_WAIT4:          "wait4",
+	unix.SYS_KILL:           "kill",
+	unix.SYS_UNAME:          "uname",
+	unix.SYS_SEMGET:         "semget",
+	unix.SYS_SEMOP:          "semop",
+	unix.SYS_SEMCTL:         "semctl",
+	unix.SYS_SHMDT:          "shmdt",
+	unix.SYS_MSGGET:         "msgget",
+	unix.SYS_MSGSND:         "msgsnd",
+	unix.SYS_MSGRCV:         "msgrcv",
+	unix.SYS_MSGCTL:         "msgctl",
+	unix.SYS_FCNTL:          "fcntl",
+	unix.SYS_FLOCK:          "flock",
+	unix.SYS_FSYNC:          "fsync",
+	unix.SYS_FDATASYNC:      "fdatasync",
+	unix.SYS_TRUNCATE:       "truncate",
+	unix.SYS_FTRUNCATE:      "ftruncate",
+	unix.SYS_GETDENTS64:     "getdents64",
+	unix.SYS_GETCWD:         "getcwd",
+	unix.SYS_CHDIR:          "chdir",
+	unix.SYS_FCHDIR:         "fchdir",
+	unix.SYS_RENAMEAT:       "renameat",
+	unix.SYS_RENAMEAT2:      "renameat2",
+	unix.SYS_MKDIRAT:        "mkdirat",
+	unix.SYS_LINKAT:         "linkat",
+	unix.SYS_UNLINKAT:       "unlinkat",
+	unix.SYS_SYMLINKAT:      "symlinkat",
+	// Note: ARM64 doesn't have SYS_READLINK, it uses readlinkat with AT_FDCWD
+	unix.SYS_FCHMOD:       "fchmod",
+	unix.SYS_FCHMODAT:     "fchmodat",
+	unix.SYS_FCHMODAT2:    "fchmodat2",
+	unix.SYS_FCHOWNAT:     "fchownat",
+	unix.SYS_FCHOWN:       "fchown",
+	unix.SYS_UMASK:        "umask",
+	unix.SYS_GETTIMEOFDAY: "gettimeofday",
+	unix.SYS_GETRLIMIT:    "getrlimit",
+	unix.SYS_GETRUSAGE:    "getrusage",
+	unix.SYS_SYSINFO:      "sysinfo",
+	unix.SYS_TIMES:        "times",
+	unix.SYS_OPENAT:       "openat",
+	unix.SYS_NEWFSTATAT:   "newfstatat",
+	unix.SYS_READLINKAT:   "readlinkat",
+	unix.SYS_EXECVEAT:     "execveat",
+	unix.SYS_STATX:        "statx",
 }

--- a/tw/pkg/commands/ptrace/syscalls_arm64.go
+++ b/tw/pkg/commands/ptrace/syscalls_arm64.go
@@ -1,0 +1,143 @@
+//go:build linux && arm64
+// +build linux,arm64
+
+package ptrace
+
+import (
+	"fmt"
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+// ARM64Handler implements the ArchHandler interface for ARM64 architecture
+type ARM64Handler struct {
+	*BaseArchHandler
+}
+
+func (h *ARM64Handler) Name() string {
+	return "ARM64"
+}
+
+// Register accessor methods
+func (h *ARM64Handler) CallFirstParam(regs unix.PtraceRegs) uint64 {
+	return uint64(regs.Regs[0])
+}
+
+func (h *ARM64Handler) CallSecondParam(regs unix.PtraceRegs) uint64 {
+	return uint64(regs.Regs[1])
+}
+
+func (h *ARM64Handler) CallThirdParam(regs unix.PtraceRegs) uint64 {
+	return uint64(regs.Regs[2])
+}
+
+func (h *ARM64Handler) CallFourthParam(regs unix.PtraceRegs) uint64 {
+	return uint64(regs.Regs[3])
+}
+
+func (h *ARM64Handler) CallFifthParam(regs unix.PtraceRegs) uint64 {
+	return uint64(regs.Regs[4])
+}
+
+func (h *ARM64Handler) CallSixthParam(regs unix.PtraceRegs) uint64 {
+	return uint64(regs.Regs[5])
+}
+
+func (h *ARM64Handler) CallReturnValue(regs unix.PtraceRegs) uint64 {
+	return uint64(regs.Regs[0])
+}
+
+// Get syscall number from registers for ARM64
+func (h *ARM64Handler) GetSyscallNumber(regs unix.PtraceRegs) uint32 {
+	return uint32(regs.Regs[8])
+}
+
+// ARM64 handler uses the base implementation for all syscall classifications
+// since we've populated the maps in the init function
+
+// ARM64-specific initialization
+func init() {
+	// Initialize the ARM64-specific architecture handler
+	base := NewBaseArchHandler()
+
+	// Register file operations
+	base.RegisterFileOp(
+		unix.SYS_OPENAT, unix.SYS_CLOSE, unix.SYS_READ, unix.SYS_WRITE,
+		unix.SYS_PREAD64, unix.SYS_PWRITE64, unix.SYS_LSEEK, unix.SYS_FSTAT,
+		unix.SYS_UNLINKAT, unix.SYS_MKDIRAT, unix.SYS_RENAMEAT, unix.SYS_RENAMEAT2,
+		unix.SYS_READLINKAT, unix.SYS_TRUNCATE, unix.SYS_FTRUNCATE, unix.SYS_FSYNC,
+		unix.SYS_FDATASYNC,
+	)
+
+	// Register network operations
+	base.RegisterNetworkOp(
+		unix.SYS_SOCKET, unix.SYS_CONNECT, unix.SYS_BIND, unix.SYS_LISTEN,
+		unix.SYS_ACCEPT, unix.SYS_ACCEPT4, unix.SYS_GETSOCKNAME, unix.SYS_GETPEERNAME,
+		unix.SYS_SOCKETPAIR, unix.SYS_SENDTO, unix.SYS_RECVFROM, unix.SYS_SHUTDOWN,
+		unix.SYS_SETSOCKOPT, unix.SYS_GETSOCKOPT, unix.SYS_SENDMSG, unix.SYS_RECVMSG,
+	)
+
+	// Register exec operations
+	base.RegisterExecOp(
+		unix.SYS_EXECVE, unix.SYS_EXECVEAT,
+	)
+
+	// Register memory operations
+	base.RegisterMemoryOp(
+		unix.SYS_MMAP, unix.SYS_MUNMAP, unix.SYS_MPROTECT, unix.SYS_MREMAP,
+		unix.SYS_MSYNC, unix.SYS_MINCORE, unix.SYS_MADVISE, unix.SYS_BRK,
+		unix.SYS_MLOCK, unix.SYS_MUNLOCK, unix.SYS_MLOCKALL, unix.SYS_MUNLOCKALL,
+	)
+
+	// Register process operations
+	base.RegisterProcessOp(
+		unix.SYS_CLONE, unix.SYS_GETPID, unix.SYS_GETPPID, unix.SYS_GETUID,
+		unix.SYS_GETEUID, unix.SYS_GETGID, unix.SYS_GETEGID, unix.SYS_SETUID,
+		unix.SYS_SETGID, unix.SYS_EXIT, unix.SYS_EXIT_GROUP, unix.SYS_WAIT4,
+		unix.SYS_SCHED_YIELD, unix.SYS_CHDIR, unix.SYS_GETCWD, unix.SYS_CAPGET,
+		unix.SYS_CAPSET, unix.SYS_PRCTL, unix.SYS_SETPRIORITY, unix.SYS_GETPRIORITY,
+	)
+
+	// Register signal operations
+	base.RegisterSignalOp(
+		unix.SYS_KILL, unix.SYS_TKILL, unix.SYS_TGKILL, unix.SYS_RT_SIGACTION,
+		unix.SYS_RT_SIGPROCMASK, unix.SYS_RT_SIGRETURN, unix.SYS_RT_SIGPENDING,
+		unix.SYS_RT_SIGTIMEDWAIT, unix.SYS_RT_SIGQUEUEINFO, unix.SYS_RT_SIGSUSPEND,
+	)
+
+	// Register time operations
+	base.RegisterTimeOp(
+		unix.SYS_NANOSLEEP, unix.SYS_GETITIMER, unix.SYS_SETITIMER,
+		unix.SYS_TIMER_CREATE, unix.SYS_TIMER_GETTIME, unix.SYS_TIMER_SETTIME,
+		unix.SYS_TIMER_DELETE, unix.SYS_CLOCK_GETTIME, unix.SYS_CLOCK_SETTIME,
+		unix.SYS_CLOCK_GETRES, unix.SYS_CLOCK_NANOSLEEP,
+	)
+
+	// Register security operations
+	base.RegisterSecurityOp(
+		unix.SYS_CAPGET, unix.SYS_CAPSET, unix.SYS_PRCTL,
+		unix.SYS_SECCOMP, unix.SYS_PTRACE,
+	)
+
+	// Register IPC operations
+	base.RegisterIpcOp(
+		unix.SYS_PIPE2, unix.SYS_FUTEX, unix.SYS_SOCKETPAIR,
+		unix.SYS_SHMGET, unix.SYS_SHMAT, unix.SYS_SHMCTL, unix.SYS_SHMDT,
+		unix.SYS_SEMGET, unix.SYS_SEMOP, unix.SYS_SEMCTL,
+		unix.SYS_MSGGET, unix.SYS_MSGSND, unix.SYS_MSGRCV, unix.SYS_MSGCTL,
+	)
+
+	archHandler = &ARM64Handler{BaseArchHandler: base}
+
+	// Debug: Print OpenAT syscall number
+	fmt.Fprintf(os.Stdout, "ARM64 init: unix.SYS_OPENAT=%d\n", unix.SYS_OPENAT)
+
+	// Let's not register openat handler here - it's registered in the common code
+	// and we're possibly registering it twice with different handlers
+}
+
+// ARM64 implementation of handleSyscall
+func (t *Tracer) handleSyscall(pid int) {
+	handleSyscall(t, pid)
+}

--- a/tw/pkg/commands/ptrace/syscalls_linux.go
+++ b/tw/pkg/commands/ptrace/syscalls_linux.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"syscall"
 
+	"github.com/chainguard-dev/clog"
 	"golang.org/x/sys/unix"
 )
 
@@ -130,7 +131,7 @@ func getStringParam(pid int, ptr uint64) string {
 	for {
 		count, err := syscall.PtracePeekData(pid, uintptr(ptr), out[:])
 		if err != nil && err != syscall.EIO {
-			fmt.Fprintf(os.Stderr, "Error reading string from pid %d at %x: %v\n", pid, ptr, err)
+			clog.Errorf("Error reading string from pid %d at %x: %v", pid, ptr, err)
 			return ""
 		}
 

--- a/tw/pkg/commands/ptrace/syscalls_linux.go
+++ b/tw/pkg/commands/ptrace/syscalls_linux.go
@@ -1,812 +1,266 @@
-// Package ptrace provides system call tracing functionality
+//go:build linux
+// +build linux
+
 package ptrace
 
 import (
+	"bytes"
 	"fmt"
 	"os"
-	"sync"
-	"time"
+	"path"
+	"path/filepath"
+	"strings"
+	"syscall"
 
 	"golang.org/x/sys/unix"
 )
 
-// Package-level variables initialized only once during init
-// These are effectively read-only after initialization, so no mutex needed
-var (
-	// Map of syscall numbers to their names
-	syscallNames = map[uint32]string{}
-
-	// Map of syscall numbers to their processors
-	syscallProcessors = map[uint32]SyscallProcessor{}
-)
-
-// ProcessRegistry manages the mapping between PIDs and their Tracers
-// This encapsulates the global state that was previously using syscallTracersMu
-type ProcessRegistry struct {
-	mu      sync.RWMutex
-	tracers map[int]*Tracer
-}
-
-// Get returns the tracer for a given PID
-func (r *ProcessRegistry) Get(pid int) (*Tracer, bool) {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
-	t, ok := r.tracers[pid]
-	return t, ok
-}
-
-// Set associates a tracer with a PID
-func (r *ProcessRegistry) Set(pid int, tracer *Tracer) {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	r.tracers[pid] = tracer
-}
-
-// Delete removes a PID from the registry
-func (r *ProcessRegistry) Delete(pid int) {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	delete(r.tracers, pid)
-}
-
-// NewProcessRegistry creates a new process registry
-func NewProcessRegistry() *ProcessRegistry {
-	return &ProcessRegistry{
-		tracers: make(map[int]*Tracer),
-	}
-}
-
-// Global process registry - the only global state we really need
-var processRegistry = NewProcessRegistry()
-
-// Common system calls that have universal numbers across architectures
-// These are syscalls that have the same number on all architectures we support
-// Architecture-specific syscall numbers should be defined in their respective files
 const (
-// Common syscalls with consistent numbers across architectures
-// We use unix.SYS_* constants from x/sys/unix for actual values in the code
-
-// More modern syscalls that are more consistent across architectures
-// We rely on the unix package to provide the correct numbers per architecture
+	cwdFD = unix.AT_FDCWD // AT_FDCWD = -0x64
 )
 
-// Specific syscall processor implementations
-type openSyscallProcessor struct {
-	*baseSyscallProcessor
-}
-
-func (p *openSyscallProcessor) OnCall(pid int, regs unix.PtraceRegs, state *syscallState) {
-	// For open syscall, the first parameter is the path
-	pathAddr := archHandler.CallFirstParam(regs)
-	path, err := getStringParam(pid, pathAddr)
-	if err != nil {
-		// Record the error but continue
-		state.pathParamErr = err
-		return
-	}
-
-	// Store path in state for use in OnReturn
-	state.pathParam = path
-}
-
-func (p *openSyscallProcessor) OnReturn(pid int, regs unix.PtraceRegs, state *syscallState) {
-	// If there was an error retrieving the path, skip processing
-	if state.pathParamErr != nil || state.pathParam == "" {
-		return
-	}
-
-	// On return, check if the open was successful and track file activity
-	retVal := archHandler.CallReturnValue(regs)
-	if p.OKReturnStatus(retVal) {
-		fdNum := int(retVal) // The return value is the file descriptor
-
-		// Add to file descriptor table
-		t, ok := processRegistry.Get(pid)
-
-		if ok && state.pathParam != "" {
-			// Add to FD table for this process
-			state.fdTable[fdNum] = FD{
-				Path:     state.pathParam,
-				Type:     "regular", // Assume regular file for now
-				OpenTime: time.Now(),
-			}
-
-			// Track file system activity
-			t.fsTracker.AddActivity(state.pathParam, pid, int(p.num), FSActivityTypeOpenFile)
-		}
-	}
-}
-
-type openatSyscallProcessor struct {
-	*baseSyscallProcessor
-}
-
-func (p *openatSyscallProcessor) OnCall(pid int, regs unix.PtraceRegs, state *syscallState) {
-	fmt.Fprintf(os.Stdout, "OPENAT SYSCALL DETECTED pid=%d\n", pid)
-	// For openat, first param is dirfd, second is path
-	dirfd := int(int32(archHandler.CallFirstParam(regs)))
-	pathAddr := archHandler.CallSecondParam(regs)
-	rawPath, err := getStringParam(pid, pathAddr)
-	if err != nil {
-		// Record the error but continue
-		state.pathParamErr = err
-		fmt.Fprintf(os.Stdout, "ERROR getting path: %v\n", err)
-		return
-	}
-
-	fmt.Fprintf(os.Stdout, "OPENAT: dirfd=%d, rawPath=%s\n", dirfd, rawPath)
-
-	// Store in state for use in OnReturn
-	state.dirfd = dirfd
-	state.pathParam = rawPath
-
-	// Generate event immediately instead of waiting for return
-	t, ok := processRegistry.Get(pid)
-
-	if ok {
-		// Resolve the path if needed
-		eventPath := rawPath
-		if dirfd != 0 && dirfd != AT_FDCWD {
-			eventPath = t.resolvePath(pid, rawPath, dirfd)
-		}
-
-		t.events <- Event{
-			Type:        EventSyscall,
-			Syscall:     p.SyscallNumber(),
-			SyscallName: p.SyscallName(),
-			Pid:         pid,
-			Path:        fmt.Sprintf("opening: %s", eventPath),
-		}
-
-		// Also directly track file system activity
-		t.fsTracker.AddActivity(eventPath, pid, int(p.SyscallNumber()), FSActivityTypeOpenFile)
-	}
-}
-
-func (p *openatSyscallProcessor) EventOnCall() bool {
-	// Generate events on syscall entry rather than exit
-	return true
-}
-
-func (p *openatSyscallProcessor) OnReturn(pid int, regs unix.PtraceRegs, state *syscallState) {
-	// If there was an error retrieving the path, skip processing
-	if state.pathParamErr != nil || state.pathParam == "" {
-		return
-	}
-
-	retVal := archHandler.CallReturnValue(regs)
-	if p.OKReturnStatus(retVal) {
-		fdNum := int(retVal)
-
-		// Resolve the full path
-		t, ok := processRegistry.Get(pid)
-
-		if ok && state.pathParam != "" {
-			resolvedPath := t.resolvePath(pid, state.pathParam, state.dirfd)
-
-			// Add to FD table
-			state.fdTable[fdNum] = FD{
-				Path:     resolvedPath,
-				Type:     "regular",
-				OpenTime: time.Now(),
-			}
-
-			// Track file system activity
-			t.fsTracker.AddActivity(resolvedPath, pid, int(p.num), FSActivityTypeOpenFile)
-		}
-	}
-}
-
-type statSyscallProcessor struct {
-	*baseSyscallProcessor
-}
-
-func (p *statSyscallProcessor) OnCall(pid int, regs unix.PtraceRegs, state *syscallState) {
-	// For stat, first param is path
-	pathAddr := archHandler.CallFirstParam(regs)
-	path, err := getStringParam(pid, pathAddr)
-	if err != nil {
-		// Record the error but continue
-		state.pathParamErr = err
-		return
-	}
-
-	state.pathParam = path
-}
-
-func (p *statSyscallProcessor) OnReturn(pid int, regs unix.PtraceRegs, state *syscallState) {
-	// If there was an error retrieving the path, skip processing
-	if state.pathParamErr != nil || state.pathParam == "" {
-		return
-	}
-
-	retVal := archHandler.CallReturnValue(regs)
-	if p.OKReturnStatus(retVal) {
-		// Track file access
-		t, ok := processRegistry.Get(pid)
-
-		if ok && state.pathParam != "" {
-			t.fsTracker.AddActivity(state.pathParam, pid, int(p.num), FSActivityTypeCheckFile)
-		}
-	}
-}
-
-type fstatatSyscallProcessor struct {
-	*baseSyscallProcessor
-}
-
-func (p *fstatatSyscallProcessor) OnCall(pid int, regs unix.PtraceRegs, state *syscallState) {
-	// For newfstatat/fstatat, first param is dirfd, second is path
-	dirfd := int(int32(archHandler.CallFirstParam(regs)))
-	pathAddr := archHandler.CallSecondParam(regs)
-	rawPath, err := getStringParam(pid, pathAddr)
-	if err != nil {
-		// Record the error but continue
-		state.pathParamErr = err
-		return
-	}
-
-	state.dirfd = dirfd
-	state.pathParam = rawPath
-}
-
-func (p *fstatatSyscallProcessor) OnReturn(pid int, regs unix.PtraceRegs, state *syscallState) {
-	// If there was an error retrieving the path, skip processing
-	if state.pathParamErr != nil || state.pathParam == "" {
-		return
-	}
-
-	retVal := archHandler.CallReturnValue(regs)
-	if p.OKReturnStatus(retVal) {
-		// Resolve the full path
-		t, ok := processRegistry.Get(pid)
-
-		if ok && state.pathParam != "" {
-			resolvedPath := t.resolvePath(pid, state.pathParam, state.dirfd)
-
-			// Track file access
-			t.fsTracker.AddActivity(resolvedPath, pid, int(p.num), FSActivityTypeCheckFile)
-		}
-	}
-}
-
-type execveSyscallProcessor struct {
-	*baseSyscallProcessor
-}
-
-func (p *execveSyscallProcessor) OnCall(pid int, regs unix.PtraceRegs, state *syscallState) {
-	// For execve, first param is path
-	pathAddr := archHandler.CallFirstParam(regs)
-	path, err := getStringParam(pid, pathAddr)
-	if err != nil {
-		// Record the error but continue
-		state.pathParamErr = err
-		return
-	}
-
-	state.pathParam = path
-}
-
-func (p *execveSyscallProcessor) OnReturn(pid int, regs unix.PtraceRegs, state *syscallState) {
-	// If there was an error retrieving the path, skip processing
-	if state.pathParamErr != nil || state.pathParam == "" {
-		return
-	}
-
-	// execve typically doesn't return on success (process image is replaced)
-	// So we need to handle this differently. Let's record the attempt regardless.
-	t, ok := processRegistry.Get(pid)
-
-	if ok && state.pathParam != "" {
-		t.fsTracker.AddActivity(state.pathParam, pid, int(p.num), FSActivityTypeExec)
-	}
-}
-
-func (p *execveSyscallProcessor) EventOnCall() bool {
-	// Generate an event when the syscall is called, don't wait for return
-	return true
-}
-
-type execveatSyscallProcessor struct {
-	*baseSyscallProcessor
-}
-
-func (p *execveatSyscallProcessor) OnCall(pid int, regs unix.PtraceRegs, state *syscallState) {
-	// For execveat, first param is dirfd, second is path
-	dirfd := int(int32(archHandler.CallFirstParam(regs)))
-	pathAddr := archHandler.CallSecondParam(regs)
-	rawPath, err := getStringParam(pid, pathAddr)
-	if err != nil {
-		// Record the error but continue
-		state.pathParamErr = err
-		return
-	}
-
-	state.dirfd = dirfd
-	state.pathParam = rawPath
-}
-
-func (p *execveatSyscallProcessor) OnReturn(pid int, regs unix.PtraceRegs, state *syscallState) {
-	// If there was an error retrieving the path, skip processing
-	if state.pathParamErr != nil || state.pathParam == "" {
-		return
-	}
-
-	// Like execve, this typically doesn't return on success
-	t, ok := processRegistry.Get(pid)
-
-	if ok && state.pathParam != "" {
-		resolvedPath := t.resolvePath(pid, state.pathParam, state.dirfd)
-		t.fsTracker.AddActivity(resolvedPath, pid, int(p.num), FSActivityTypeExec)
-	}
-}
-
-func (p *execveatSyscallProcessor) EventOnCall() bool {
-	return true
-}
-
-// We now use processRegistry instead of a global map with a mutex
-
-// initSyscallNames initializes the cross-platform syscall names map
-// This is called from the package init function to populate
-// the syscallNames map with syscalls that are common across architectures
-func initSyscallNames() {
-	// No locks needed since this only happens during init
-	// and before any goroutines are started
-
-	// Build our cross-platform syscall name map
-	// using the actual syscall numbers from the unix package
-	// These should work on both architectures
-	syscallNames[unix.SYS_READ] = "read"
-	syscallNames[unix.SYS_WRITE] = "write"
-	syscallNames[unix.SYS_CLOSE] = "close"
-	syscallNames[unix.SYS_FSTAT] = "fstat"
-	syscallNames[unix.SYS_LSEEK] = "lseek"
-	syscallNames[unix.SYS_MMAP] = "mmap"
-	syscallNames[unix.SYS_MPROTECT] = "mprotect"
-	syscallNames[unix.SYS_MUNMAP] = "munmap"
-	syscallNames[unix.SYS_BRK] = "brk"
-	syscallNames[unix.SYS_RT_SIGACTION] = "rt_sigaction"
-	syscallNames[unix.SYS_RT_SIGPROCMASK] = "rt_sigprocmask"
-	syscallNames[unix.SYS_RT_SIGRETURN] = "rt_sigreturn"
-	syscallNames[unix.SYS_IOCTL] = "ioctl"
-	syscallNames[unix.SYS_PREAD64] = "pread64"
-	syscallNames[unix.SYS_PWRITE64] = "pwrite64"
-	syscallNames[unix.SYS_READV] = "readv"
-	syscallNames[unix.SYS_WRITEV] = "writev"
-	// syscallNames[unix.SYS_ACCESS] = "access"
-	// syscallNames[unix.SYS_PIPE] = "pipe"
-	// syscallNames[unix.SYS_SELECT] = "select"
-	syscallNames[unix.SYS_SCHED_YIELD] = "sched_yield"
-	syscallNames[unix.SYS_MREMAP] = "mremap"
-	syscallNames[unix.SYS_MSYNC] = "msync"
-	syscallNames[unix.SYS_MINCORE] = "mincore"
-	syscallNames[unix.SYS_MADVISE] = "madvise"
-	syscallNames[unix.SYS_DUP] = "dup"
-	syscallNames[unix.SYS_NANOSLEEP] = "nanosleep"
-	syscallNames[unix.SYS_GETITIMER] = "getitimer"
-	syscallNames[unix.SYS_SETITIMER] = "setitimer"
-	syscallNames[unix.SYS_GETPID] = "getpid"
-	syscallNames[unix.SYS_SENDFILE] = "sendfile"
-	syscallNames[unix.SYS_SOCKET] = "socket"
-	syscallNames[unix.SYS_CONNECT] = "connect"
-	syscallNames[unix.SYS_ACCEPT] = "accept"
-	syscallNames[unix.SYS_SENDTO] = "sendto"
-	syscallNames[unix.SYS_RECVFROM] = "recvfrom"
-	syscallNames[unix.SYS_SENDMSG] = "sendmsg"
-	syscallNames[unix.SYS_RECVMSG] = "recvmsg"
-	syscallNames[unix.SYS_SHUTDOWN] = "shutdown"
-	syscallNames[unix.SYS_BIND] = "bind"
-	syscallNames[unix.SYS_LISTEN] = "listen"
-	syscallNames[unix.SYS_GETSOCKNAME] = "getsockname"
-	syscallNames[unix.SYS_GETPEERNAME] = "getpeername"
-	syscallNames[unix.SYS_SOCKETPAIR] = "socketpair"
-	syscallNames[unix.SYS_SETSOCKOPT] = "setsockopt"
-	syscallNames[unix.SYS_GETSOCKOPT] = "getsockopt"
-	syscallNames[unix.SYS_CLONE] = "clone"
-	syscallNames[unix.SYS_EXECVE] = "execve"
-	syscallNames[unix.SYS_EXIT] = "exit"
-	syscallNames[unix.SYS_FCNTL] = "fcntl"
-	syscallNames[unix.SYS_FSYNC] = "fsync"
-	syscallNames[unix.SYS_TRUNCATE] = "truncate"
-	syscallNames[unix.SYS_FTRUNCATE] = "ftruncate"
-	// syscallNames[unix.SYS_GETDENTS] = "getdents"
-
-	// AT family syscalls (more modern, work on both architectures)
-	syscallNames[unix.SYS_OPENAT] = "openat"
-	syscallNames[unix.SYS_MKDIRAT] = "mkdirat"
-	syscallNames[unix.SYS_UNLINKAT] = "unlinkat"
-	syscallNames[unix.SYS_RENAMEAT] = "renameat"
-	syscallNames[unix.SYS_RENAMEAT2] = "renameat2"
-	syscallNames[unix.SYS_EXECVEAT] = "execveat"
-	syscallNames[unix.SYS_ACCEPT4] = "accept4"
-
-	// Note: Syscall processors are now registered in registerCommonSyscallProcessors()
-	// to avoid duplicate registration
-}
-
-// Cross-platform init
-func init() {
-	// Everything here runs during init time only, before any goroutines start
-	// so no locking is needed
-	initSyscallNames()
-	registerCommonSyscallProcessors()
-
-	// Note: We're now using processRegistry instead of syscallTracers
-}
-
-// registerCommonSyscallProcessors registers the common syscall processors that are available
-// across all architectures. Architecture-specific processors are registered in their
-// respective architecture initialization files.
-func registerCommonSyscallProcessors() {
-	// Register common syscall processors
-	RegisterSyscallProcessor(&openatSyscallProcessor{
-		baseSyscallProcessor: &baseSyscallProcessor{
-			num:         unix.SYS_OPENAT,
-			name:        "openat",
-			syscallType: OpenFileType,
-		},
-	})
-
-	RegisterSyscallProcessor(&fstatatSyscallProcessor{
-		baseSyscallProcessor: &baseSyscallProcessor{
-			num:         unix.SYS_NEWFSTATAT,
-			name:        "newfstatat",
-			syscallType: CheckFileType,
-		},
-	})
-
-	RegisterSyscallProcessor(&execveSyscallProcessor{
-		baseSyscallProcessor: &baseSyscallProcessor{
-			num:         unix.SYS_EXECVE,
-			name:        "execve",
-			syscallType: ExecType,
-		},
-	})
-
-	RegisterSyscallProcessor(&execveatSyscallProcessor{
-		baseSyscallProcessor: &baseSyscallProcessor{
-			num:         unix.SYS_EXECVEAT,
-			name:        "execveat",
-			syscallType: ExecType,
-		},
-	})
-
-	// Note: Architecture-specific syscalls (like SYS_OPEN and SYS_STAT for amd64)
-	// are registered in their respective arch-specific init functions
-}
-
-// Return human-readable names for system calls
-func getSyscallName(num uint32) string {
-	// No lock needed since syscallNames is read-only after init
-	if name, ok := syscallNames[num]; ok {
-		return name
-	}
-	return fmt.Sprintf("unknown(%d)", num)
-}
-
-// SyscallType represents the type of syscall operation
+// SyscallType defines types of syscalls we handle
 type SyscallType string
 
 const (
-	// Types of syscalls
-	CheckFileType SyscallType = "type.checkfile" // Syscalls that check file existence/stats (stat, access, etc.)
-	OpenFileType  SyscallType = "type.openfile"  // Syscalls that open files (open, openat, etc.)
-	ExecType      SyscallType = "type.exec"      // Syscalls that execute processes (execve, execveat)
-	NetworkType   SyscallType = "type.network"   // Syscalls for network operations (socket, connect, etc.)
-	MemoryType    SyscallType = "type.memory"    // Syscalls for memory operations (mmap, etc.)
-	ProcessType   SyscallType = "type.process"   // Syscalls for process operations (fork, etc.)
-	SignalType    SyscallType = "type.signal"    // Syscalls for signal handling
-	TimeType      SyscallType = "type.time"      // Syscalls for time operations
-	SecurityType  SyscallType = "type.security"  // Syscalls for security operations
-	IpcType       SyscallType = "type.ipc"       // Syscalls for IPC operations
-	MiscType      SyscallType = "type.misc"      // Syscalls that don't fit other categories
+	CheckFileType SyscallType = "check_file" // Syscalls that check file existence (stat, access)
+	OpenFileType  SyscallType = "open_file"  // Syscalls that open files (open, openat)
+	ExecType      SyscallType = "exec"       // Syscalls that execute programs (execve, execveat)
 )
 
-// SyscallProcessor interfaces define how to process different syscalls
-type SyscallProcessor interface {
-	SyscallNumber() uint32
-	SyscallName() string
-	SyscallType() SyscallType
-	OnCall(pid int, regs unix.PtraceRegs, state *syscallState)
-	OnReturn(pid int, regs unix.PtraceRegs, state *syscallState)
-	EventOnCall() bool
-	OKReturnStatus(retVal uint64) bool
-}
-
-// Base syscall processor implementation with common functionality
-type baseSyscallProcessor struct {
+// BaseSyscallHandler provides common functionality for syscall handlers
+type BaseSyscallHandler struct {
 	num         uint32
 	name        string
 	syscallType SyscallType
+	stringParam int // Position of string param (0=none, 1=first, 2=second)
 }
 
-func (p *baseSyscallProcessor) SyscallNumber() uint32 {
-	return p.num
+func (h *BaseSyscallHandler) SyscallNumber() int {
+	return int(h.num)
 }
 
-func (p *baseSyscallProcessor) SyscallName() string {
-	return p.name
+func (h *BaseSyscallHandler) SyscallName() string {
+	return h.name
 }
 
-func (p *baseSyscallProcessor) SyscallType() SyscallType {
-	return p.syscallType
+func (h *BaseSyscallHandler) SyscallType() SyscallType {
+	return h.syscallType
 }
 
-func (p *baseSyscallProcessor) EventOnCall() bool {
+// OnCall extracts pathParam from syscall arguments
+func (h *BaseSyscallHandler) OnCall(pid int, regs syscall.PtraceRegs, state *SyscallState) {
+	var pth, dir string
+	var fd int
+
+	switch h.stringParam {
+	case 0:
+		// No string parameter
+		return
+	case 1:
+		// First parameter is a path string
+		pth = getStringParam(pid, getFirstParam(regs))
+	case 2:
+		// First parameter is a file descriptor, second is a path string
+		fd = getIntParam(pid, getFirstParam(regs))
+
+		// Handle AT_FDCWD specially
+		if fd == cwdFD { // cwdFD = unix.AT_FDCWD
+			dir, _ = os.Readlink(fmt.Sprintf("/proc/%d/cwd", pid))
+		} else if fd > 2 { // Skip stdin/stdout/stderr
+			dir, _ = os.Readlink(fmt.Sprintf("/proc/%d/fd/%d", pid, fd))
+		}
+
+		pth = getStringParam(pid, getSecondParam(regs))
+	}
+
+	// Handle path resolution
+	if len(pth) == 0 {
+		// Empty path handling
+		if dir != "" {
+			// Empty path with directory fd
+			pth = dir
+		} else if fd == cwdFD {
+			// Empty path with AT_FDCWD
+			cwd, _ := os.Readlink(fmt.Sprintf("/proc/%d/cwd", pid))
+			pth = cwd
+		}
+	} else if pth[0] != '/' {
+		// Relative path handling
+		if dir != "" {
+			// Relative to directory fd
+			pth = path.Join(dir, pth)
+		} else if fd == cwdFD {
+			// Relative to current working directory
+			cwd, _ := os.Readlink(fmt.Sprintf("/proc/%d/cwd", pid))
+			if cwd != "" {
+				pth = path.Join(cwd, pth)
+			}
+		}
+	}
+
+	// Some syscalls like readlinkat can have empty path with non-AT_FDCWD fd
+	// In those cases, we want to use the fd's target as the path
+	if pth == "" && fd > 2 {
+		fdPath, err := os.Readlink(fmt.Sprintf("/proc/%d/fd/%d", pid, fd))
+		if err == nil && fdPath != "" {
+			pth = fdPath
+		}
+	}
+
+	// Clean the path and store it
+	if pth != "" {
+		state.pathParam = filepath.Clean(pth)
+	}
+}
+
+// OnReturn handles syscall return
+func (h *BaseSyscallHandler) OnReturn(pid int, regs syscall.PtraceRegs, state *SyscallState) {
+	// Default implementation does nothing
+}
+
+// Helper function to get string parameter from process memory
+func getStringParam(pid int, ptr uint64) string {
+	if ptr == 0 {
+		return ""
+	}
+
+	var out [256]byte
+	var data []byte
+	for {
+		count, err := syscall.PtracePeekData(pid, uintptr(ptr), out[:])
+		if err != nil && err != syscall.EIO {
+			fmt.Fprintf(os.Stderr, "Error reading string from pid %d at %x: %v\n", pid, ptr, err)
+			return ""
+		}
+
+		if count <= 0 {
+			break
+		}
+
+		idx := bytes.IndexByte(out[:count], 0)
+		var foundNull bool
+		if idx == -1 {
+			idx = count
+			ptr += uint64(count)
+		} else {
+			foundNull = true
+		}
+
+		data = append(data, out[:idx]...)
+		if foundNull {
+			return string(data)
+		}
+	}
+
+	return string(data)
+}
+
+// Helper function to get integer parameter from syscall
+func getIntParam(pid int, ptr uint64) int {
+	return int(int32(ptr))
+}
+
+//-------- Specific handler types --------//
+
+// FileCheckHandler handles syscalls that check file existence (stat, access, etc.)
+type FileCheckHandler struct {
+	BaseSyscallHandler
+}
+
+func NewFileCheckHandler(num uint32, name string, stringParam int) *FileCheckHandler {
+	return &FileCheckHandler{
+		BaseSyscallHandler: BaseSyscallHandler{
+			num:         num,
+			name:        name,
+			syscallType: CheckFileType,
+			stringParam: stringParam,
+		},
+	}
+}
+
+func (h *FileCheckHandler) OKReturnStatus(retVal uint64) bool {
+	return int32(retVal) == 0 // For check calls, 0 is success
+}
+
+// FileOpenHandler handles syscalls that open files (open, openat, etc.)
+type FileOpenHandler struct {
+	BaseSyscallHandler
+}
+
+func NewFileOpenHandler(num uint32, name string, stringParam int) *FileOpenHandler {
+	return &FileOpenHandler{
+		BaseSyscallHandler: BaseSyscallHandler{
+			num:         num,
+			name:        name,
+			syscallType: OpenFileType,
+			stringParam: stringParam,
+		},
+	}
+}
+
+func (h *FileOpenHandler) OKReturnStatus(retVal uint64) bool {
+	fd := int32(retVal)
+	return fd >= 0 // For open-type calls, non-negative FD is success
+}
+
+// ExecHandler handles syscalls that execute programs (execve, execveat)
+type ExecHandler struct {
+	BaseSyscallHandler
+}
+
+func NewExecHandler(num uint32, name string, stringParam int) *ExecHandler {
+	return &ExecHandler{
+		BaseSyscallHandler: BaseSyscallHandler{
+			num:         num,
+			name:        name,
+			syscallType: ExecType,
+			stringParam: stringParam,
+		},
+	}
+}
+
+func (h *ExecHandler) OKReturnStatus(retVal uint64) bool {
+	// For exec calls, success means the call doesn't return (new program takes over)
+	// So if we get a return value, it generally means it failed
+	fd := int(int32(retVal))
+	return fd >= 0
+}
+
+// shouldSkipPath determines if a path should be excluded from tracking
+func shouldSkipPath(path string) bool {
+	// Skip common system paths and special files
+	if path == "" || path == "." || path == "/" {
+		return true
+	}
+
+	// Skip procfs
+	if strings.HasPrefix(path, "/proc/") || path == "/proc" {
+		return true
+	}
+
+	// Skip sysfs
+	if strings.HasPrefix(path, "/sys/") || path == "/sys" {
+		return true
+	}
+
+	// Skip devfs
+	if strings.HasPrefix(path, "/dev/") || path == "/dev" {
+		return true
+	}
+
 	return false
 }
 
-func (p *baseSyscallProcessor) OKReturnStatus(retVal uint64) bool {
-	// Default implementation - success if return value >= 0
-	return int64(retVal) >= 0
-}
-
-// RegisterSyscallProcessor adds a processor for a syscall
-// This should only be called during init time
-func RegisterSyscallProcessor(processor SyscallProcessor) {
-	// No locking needed since this happens during init
-	syscallProcessors[processor.SyscallNumber()] = processor
-}
-
-// GetSyscallProcessor returns the processor for a given syscall, or nil if not found
-func GetSyscallProcessor(syscallNum uint32) SyscallProcessor {
-	// No lock needed since syscallProcessors is read-only after init
-	return syscallProcessors[syscallNum]
-}
-
-// BaseArchHandler provides common functionality for architecture handlers
-type BaseArchHandler struct {
-	fileOps     map[uint32]bool
-	networkOps  map[uint32]bool
-	execOps     map[uint32]bool
-	memoryOps   map[uint32]bool
-	processOps  map[uint32]bool
-	signalOps   map[uint32]bool
-	timeOps     map[uint32]bool
-	securityOps map[uint32]bool
-	ipcOps      map[uint32]bool
-}
-
-// NewBaseArchHandler creates a new base architecture handler
-func NewBaseArchHandler() *BaseArchHandler {
-	return &BaseArchHandler{
-		fileOps:     make(map[uint32]bool),
-		networkOps:  make(map[uint32]bool),
-		execOps:     make(map[uint32]bool),
-		memoryOps:   make(map[uint32]bool),
-		processOps:  make(map[uint32]bool),
-		signalOps:   make(map[uint32]bool),
-		timeOps:     make(map[uint32]bool),
-		securityOps: make(map[uint32]bool),
-		ipcOps:      make(map[uint32]bool),
-	}
-}
-
-// RegisterFileOp registers syscalls as file operations
-func (h *BaseArchHandler) RegisterFileOp(syscalls ...uint32) {
-	for _, num := range syscalls {
-		h.fileOps[num] = true
-	}
-}
-
-// RegisterNetworkOp registers syscalls as network operations
-func (h *BaseArchHandler) RegisterNetworkOp(syscalls ...uint32) {
-	for _, num := range syscalls {
-		h.networkOps[num] = true
-	}
-}
-
-// RegisterExecOp registers syscalls as exec operations
-func (h *BaseArchHandler) RegisterExecOp(syscalls ...uint32) {
-	for _, num := range syscalls {
-		h.execOps[num] = true
-	}
-}
-
-// RegisterMemoryOp registers syscalls as memory operations
-func (h *BaseArchHandler) RegisterMemoryOp(syscalls ...uint32) {
-	for _, num := range syscalls {
-		h.memoryOps[num] = true
-	}
-}
-
-// RegisterProcessOp registers syscalls as process operations
-func (h *BaseArchHandler) RegisterProcessOp(syscalls ...uint32) {
-	for _, num := range syscalls {
-		h.processOps[num] = true
-	}
-}
-
-// RegisterSignalOp registers syscalls as signal operations
-func (h *BaseArchHandler) RegisterSignalOp(syscalls ...uint32) {
-	for _, num := range syscalls {
-		h.signalOps[num] = true
-	}
-}
-
-// RegisterTimeOp registers syscalls as time operations
-func (h *BaseArchHandler) RegisterTimeOp(syscalls ...uint32) {
-	for _, num := range syscalls {
-		h.timeOps[num] = true
-	}
-}
-
-// RegisterSecurityOp registers syscalls as security operations
-func (h *BaseArchHandler) RegisterSecurityOp(syscalls ...uint32) {
-	for _, num := range syscalls {
-		h.securityOps[num] = true
-	}
-}
-
-// RegisterIpcOp registers syscalls as IPC operations
-func (h *BaseArchHandler) RegisterIpcOp(syscalls ...uint32) {
-	for _, num := range syscalls {
-		h.ipcOps[num] = true
-	}
-}
-
-// IsFileOpSyscall returns true if the syscall is a file operation
-func (h *BaseArchHandler) IsFileOpSyscall(num uint32) bool {
-	return h.fileOps[num]
-}
-
-// IsNetworkSyscall returns true if the syscall is a network operation
-func (h *BaseArchHandler) IsNetworkSyscall(num uint32) bool {
-	return h.networkOps[num]
-}
-
-// IsExecSyscall returns true if the syscall is an exec operation
-func (h *BaseArchHandler) IsExecSyscall(num uint32) bool {
-	return h.execOps[num]
-}
-
-// IsMemorySyscall returns true if the syscall is a memory operation
-func (h *BaseArchHandler) IsMemorySyscall(num uint32) bool {
-	return h.memoryOps[num]
-}
-
-// IsProcessSyscall returns true if the syscall is a process operation
-func (h *BaseArchHandler) IsProcessSyscall(num uint32) bool {
-	return h.processOps[num]
-}
-
-// IsSignalSyscall returns true if the syscall is a signal operation
-func (h *BaseArchHandler) IsSignalSyscall(num uint32) bool {
-	return h.signalOps[num]
-}
-
-// IsTimeSyscall returns true if the syscall is a time operation
-func (h *BaseArchHandler) IsTimeSyscall(num uint32) bool {
-	return h.timeOps[num]
-}
-
-// IsSecuritySyscall returns true if the syscall is a security operation
-func (h *BaseArchHandler) IsSecuritySyscall(num uint32) bool {
-	return h.securityOps[num]
-}
-
-// IsIpcSyscall returns true if the syscall is an IPC operation
-func (h *BaseArchHandler) IsIpcSyscall(num uint32) bool {
-	return h.ipcOps[num]
-}
-
-// ArchHandler defines an interface for architecture-specific operations
-// This interface will be implemented in the arch-specific files
-type ArchHandler interface {
-	// Register operations
-	CallFirstParam(regs unix.PtraceRegs) uint64
-	CallSecondParam(regs unix.PtraceRegs) uint64
-	CallThirdParam(regs unix.PtraceRegs) uint64
-	CallFourthParam(regs unix.PtraceRegs) uint64
-	CallFifthParam(regs unix.PtraceRegs) uint64
-	CallSixthParam(regs unix.PtraceRegs) uint64
-	CallReturnValue(regs unix.PtraceRegs) uint64
-
-	// System call operations
-	GetSyscallNumber(regs unix.PtraceRegs) uint32
-
-	// Architecture-specific classification
-	IsFileOpSyscall(num uint32) bool
-	IsNetworkSyscall(num uint32) bool
-	IsExecSyscall(num uint32) bool
-	IsMemorySyscall(num uint32) bool
-	IsProcessSyscall(num uint32) bool
-	IsSignalSyscall(num uint32) bool
-	IsTimeSyscall(num uint32) bool
-	IsSecuritySyscall(num uint32) bool
-	IsIpcSyscall(num uint32) bool
-
-	// Architecture name for logging
-	Name() string
-}
-
-// Architecture-specific handler is set at init time
-var archHandler ArchHandler
-
-// Wrapper functions for syscall classification
-// These delegate to the architecture-specific handler
-
-// IsFileOpSyscall checks if a syscall is related to file operations
-func IsFileOpSyscall(num uint32) bool {
-	return archHandler.IsFileOpSyscall(num)
-}
-
-// IsNetworkSyscall checks if a syscall is related to network operations
-func IsNetworkSyscall(num uint32) bool {
-	return archHandler.IsNetworkSyscall(num)
-}
-
-// IsExecSyscall checks if a syscall is related to process execution
-func IsExecSyscall(num uint32) bool {
-	return archHandler.IsExecSyscall(num)
-}
-
-// IsMemorySyscall checks if a syscall is related to memory management
-func IsMemorySyscall(num uint32) bool {
-	return archHandler.IsMemorySyscall(num)
-}
-
-// IsProcessSyscall checks if a syscall is related to process management (non-exec)
-func IsProcessSyscall(num uint32) bool {
-	return archHandler.IsProcessSyscall(num)
-}
-
-// IsSignalSyscall checks if a syscall is related to signal handling
-func IsSignalSyscall(num uint32) bool {
-	return archHandler.IsSignalSyscall(num)
-}
-
-// IsTimeSyscall checks if a syscall is related to time operations
-func IsTimeSyscall(num uint32) bool {
-	return archHandler.IsTimeSyscall(num)
-}
-
-// IsSecuritySyscall checks if a syscall is related to security operations
-func IsSecuritySyscall(num uint32) bool {
-	return archHandler.IsSecuritySyscall(num)
-}
-
-// IsIpcSyscall checks if a syscall is related to inter-process communication
-func IsIpcSyscall(num uint32) bool {
-	return archHandler.IsIpcSyscall(num)
-}
-
-// GetSyscallType returns the type of syscall based on classification functions
-func GetSyscallType(syscallNum uint32) SyscallType {
-	// Check for specific processor first
-	if processor := GetSyscallProcessor(syscallNum); processor != nil {
-		return processor.SyscallType()
+// truncatePath shortens a path to fit in maxLen characters
+// It preserves the beginning and end of the path, removing the middle if needed
+func truncatePath(path string, maxLen int) string {
+	if len(path) <= maxLen {
+		return path
 	}
 
-	// Otherwise use the general classification functions
-	switch {
-	case IsFileOpSyscall(syscallNum):
-		// Further classify file ops
-		// This is a simplified check - ideally we'd have a more comprehensive classification
-		for _, openSyscall := range []uint32{unix.SYS_OPENAT} {
-			if syscallNum == openSyscall {
-				return OpenFileType
-			}
-		}
-		return CheckFileType
-	case IsExecSyscall(syscallNum):
-		return ExecType
-	case IsNetworkSyscall(syscallNum):
-		return NetworkType
-	case IsMemorySyscall(syscallNum):
-		return MemoryType
-	case IsProcessSyscall(syscallNum):
-		return ProcessType
-	case IsSignalSyscall(syscallNum):
-		return SignalType
-	case IsTimeSyscall(syscallNum):
-		return TimeType
-	case IsSecuritySyscall(syscallNum):
-		return SecurityType
-	case IsIpcSyscall(syscallNum):
-		return IpcType
-	default:
-		return MiscType
-	}
+	// Keep the first part and the last part, add ellipsis in between
+	firstPart := maxLen / 2
+	lastPart := maxLen - firstPart - 3 // for the "..."
+	return path[:firstPart] + "..." + path[len(path)-lastPart:]
 }

--- a/tw/pkg/commands/ptrace/syscalls_linux.go
+++ b/tw/pkg/commands/ptrace/syscalls_linux.go
@@ -1,0 +1,812 @@
+// Package ptrace provides system call tracing functionality
+package ptrace
+
+import (
+	"fmt"
+	"os"
+	"sync"
+	"time"
+
+	"golang.org/x/sys/unix"
+)
+
+// Package-level variables initialized only once during init
+// These are effectively read-only after initialization, so no mutex needed
+var (
+	// Map of syscall numbers to their names
+	syscallNames = map[uint32]string{}
+
+	// Map of syscall numbers to their processors
+	syscallProcessors = map[uint32]SyscallProcessor{}
+)
+
+// ProcessRegistry manages the mapping between PIDs and their Tracers
+// This encapsulates the global state that was previously using syscallTracersMu
+type ProcessRegistry struct {
+	mu      sync.RWMutex
+	tracers map[int]*Tracer
+}
+
+// Get returns the tracer for a given PID
+func (r *ProcessRegistry) Get(pid int) (*Tracer, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	t, ok := r.tracers[pid]
+	return t, ok
+}
+
+// Set associates a tracer with a PID
+func (r *ProcessRegistry) Set(pid int, tracer *Tracer) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.tracers[pid] = tracer
+}
+
+// Delete removes a PID from the registry
+func (r *ProcessRegistry) Delete(pid int) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	delete(r.tracers, pid)
+}
+
+// NewProcessRegistry creates a new process registry
+func NewProcessRegistry() *ProcessRegistry {
+	return &ProcessRegistry{
+		tracers: make(map[int]*Tracer),
+	}
+}
+
+// Global process registry - the only global state we really need
+var processRegistry = NewProcessRegistry()
+
+// Common system calls that have universal numbers across architectures
+// These are syscalls that have the same number on all architectures we support
+// Architecture-specific syscall numbers should be defined in their respective files
+const (
+// Common syscalls with consistent numbers across architectures
+// We use unix.SYS_* constants from x/sys/unix for actual values in the code
+
+// More modern syscalls that are more consistent across architectures
+// We rely on the unix package to provide the correct numbers per architecture
+)
+
+// Specific syscall processor implementations
+type openSyscallProcessor struct {
+	*baseSyscallProcessor
+}
+
+func (p *openSyscallProcessor) OnCall(pid int, regs unix.PtraceRegs, state *syscallState) {
+	// For open syscall, the first parameter is the path
+	pathAddr := archHandler.CallFirstParam(regs)
+	path, err := getStringParam(pid, pathAddr)
+	if err != nil {
+		// Record the error but continue
+		state.pathParamErr = err
+		return
+	}
+
+	// Store path in state for use in OnReturn
+	state.pathParam = path
+}
+
+func (p *openSyscallProcessor) OnReturn(pid int, regs unix.PtraceRegs, state *syscallState) {
+	// If there was an error retrieving the path, skip processing
+	if state.pathParamErr != nil || state.pathParam == "" {
+		return
+	}
+
+	// On return, check if the open was successful and track file activity
+	retVal := archHandler.CallReturnValue(regs)
+	if p.OKReturnStatus(retVal) {
+		fdNum := int(retVal) // The return value is the file descriptor
+
+		// Add to file descriptor table
+		t, ok := processRegistry.Get(pid)
+
+		if ok && state.pathParam != "" {
+			// Add to FD table for this process
+			state.fdTable[fdNum] = FD{
+				Path:     state.pathParam,
+				Type:     "regular", // Assume regular file for now
+				OpenTime: time.Now(),
+			}
+
+			// Track file system activity
+			t.fsTracker.AddActivity(state.pathParam, pid, int(p.num), FSActivityTypeOpenFile)
+		}
+	}
+}
+
+type openatSyscallProcessor struct {
+	*baseSyscallProcessor
+}
+
+func (p *openatSyscallProcessor) OnCall(pid int, regs unix.PtraceRegs, state *syscallState) {
+	fmt.Fprintf(os.Stdout, "OPENAT SYSCALL DETECTED pid=%d\n", pid)
+	// For openat, first param is dirfd, second is path
+	dirfd := int(int32(archHandler.CallFirstParam(regs)))
+	pathAddr := archHandler.CallSecondParam(regs)
+	rawPath, err := getStringParam(pid, pathAddr)
+	if err != nil {
+		// Record the error but continue
+		state.pathParamErr = err
+		fmt.Fprintf(os.Stdout, "ERROR getting path: %v\n", err)
+		return
+	}
+
+	fmt.Fprintf(os.Stdout, "OPENAT: dirfd=%d, rawPath=%s\n", dirfd, rawPath)
+
+	// Store in state for use in OnReturn
+	state.dirfd = dirfd
+	state.pathParam = rawPath
+
+	// Generate event immediately instead of waiting for return
+	t, ok := processRegistry.Get(pid)
+
+	if ok {
+		// Resolve the path if needed
+		eventPath := rawPath
+		if dirfd != 0 && dirfd != AT_FDCWD {
+			eventPath = t.resolvePath(pid, rawPath, dirfd)
+		}
+
+		t.events <- Event{
+			Type:        EventSyscall,
+			Syscall:     p.SyscallNumber(),
+			SyscallName: p.SyscallName(),
+			Pid:         pid,
+			Path:        fmt.Sprintf("opening: %s", eventPath),
+		}
+
+		// Also directly track file system activity
+		t.fsTracker.AddActivity(eventPath, pid, int(p.SyscallNumber()), FSActivityTypeOpenFile)
+	}
+}
+
+func (p *openatSyscallProcessor) EventOnCall() bool {
+	// Generate events on syscall entry rather than exit
+	return true
+}
+
+func (p *openatSyscallProcessor) OnReturn(pid int, regs unix.PtraceRegs, state *syscallState) {
+	// If there was an error retrieving the path, skip processing
+	if state.pathParamErr != nil || state.pathParam == "" {
+		return
+	}
+
+	retVal := archHandler.CallReturnValue(regs)
+	if p.OKReturnStatus(retVal) {
+		fdNum := int(retVal)
+
+		// Resolve the full path
+		t, ok := processRegistry.Get(pid)
+
+		if ok && state.pathParam != "" {
+			resolvedPath := t.resolvePath(pid, state.pathParam, state.dirfd)
+
+			// Add to FD table
+			state.fdTable[fdNum] = FD{
+				Path:     resolvedPath,
+				Type:     "regular",
+				OpenTime: time.Now(),
+			}
+
+			// Track file system activity
+			t.fsTracker.AddActivity(resolvedPath, pid, int(p.num), FSActivityTypeOpenFile)
+		}
+	}
+}
+
+type statSyscallProcessor struct {
+	*baseSyscallProcessor
+}
+
+func (p *statSyscallProcessor) OnCall(pid int, regs unix.PtraceRegs, state *syscallState) {
+	// For stat, first param is path
+	pathAddr := archHandler.CallFirstParam(regs)
+	path, err := getStringParam(pid, pathAddr)
+	if err != nil {
+		// Record the error but continue
+		state.pathParamErr = err
+		return
+	}
+
+	state.pathParam = path
+}
+
+func (p *statSyscallProcessor) OnReturn(pid int, regs unix.PtraceRegs, state *syscallState) {
+	// If there was an error retrieving the path, skip processing
+	if state.pathParamErr != nil || state.pathParam == "" {
+		return
+	}
+
+	retVal := archHandler.CallReturnValue(regs)
+	if p.OKReturnStatus(retVal) {
+		// Track file access
+		t, ok := processRegistry.Get(pid)
+
+		if ok && state.pathParam != "" {
+			t.fsTracker.AddActivity(state.pathParam, pid, int(p.num), FSActivityTypeCheckFile)
+		}
+	}
+}
+
+type fstatatSyscallProcessor struct {
+	*baseSyscallProcessor
+}
+
+func (p *fstatatSyscallProcessor) OnCall(pid int, regs unix.PtraceRegs, state *syscallState) {
+	// For newfstatat/fstatat, first param is dirfd, second is path
+	dirfd := int(int32(archHandler.CallFirstParam(regs)))
+	pathAddr := archHandler.CallSecondParam(regs)
+	rawPath, err := getStringParam(pid, pathAddr)
+	if err != nil {
+		// Record the error but continue
+		state.pathParamErr = err
+		return
+	}
+
+	state.dirfd = dirfd
+	state.pathParam = rawPath
+}
+
+func (p *fstatatSyscallProcessor) OnReturn(pid int, regs unix.PtraceRegs, state *syscallState) {
+	// If there was an error retrieving the path, skip processing
+	if state.pathParamErr != nil || state.pathParam == "" {
+		return
+	}
+
+	retVal := archHandler.CallReturnValue(regs)
+	if p.OKReturnStatus(retVal) {
+		// Resolve the full path
+		t, ok := processRegistry.Get(pid)
+
+		if ok && state.pathParam != "" {
+			resolvedPath := t.resolvePath(pid, state.pathParam, state.dirfd)
+
+			// Track file access
+			t.fsTracker.AddActivity(resolvedPath, pid, int(p.num), FSActivityTypeCheckFile)
+		}
+	}
+}
+
+type execveSyscallProcessor struct {
+	*baseSyscallProcessor
+}
+
+func (p *execveSyscallProcessor) OnCall(pid int, regs unix.PtraceRegs, state *syscallState) {
+	// For execve, first param is path
+	pathAddr := archHandler.CallFirstParam(regs)
+	path, err := getStringParam(pid, pathAddr)
+	if err != nil {
+		// Record the error but continue
+		state.pathParamErr = err
+		return
+	}
+
+	state.pathParam = path
+}
+
+func (p *execveSyscallProcessor) OnReturn(pid int, regs unix.PtraceRegs, state *syscallState) {
+	// If there was an error retrieving the path, skip processing
+	if state.pathParamErr != nil || state.pathParam == "" {
+		return
+	}
+
+	// execve typically doesn't return on success (process image is replaced)
+	// So we need to handle this differently. Let's record the attempt regardless.
+	t, ok := processRegistry.Get(pid)
+
+	if ok && state.pathParam != "" {
+		t.fsTracker.AddActivity(state.pathParam, pid, int(p.num), FSActivityTypeExec)
+	}
+}
+
+func (p *execveSyscallProcessor) EventOnCall() bool {
+	// Generate an event when the syscall is called, don't wait for return
+	return true
+}
+
+type execveatSyscallProcessor struct {
+	*baseSyscallProcessor
+}
+
+func (p *execveatSyscallProcessor) OnCall(pid int, regs unix.PtraceRegs, state *syscallState) {
+	// For execveat, first param is dirfd, second is path
+	dirfd := int(int32(archHandler.CallFirstParam(regs)))
+	pathAddr := archHandler.CallSecondParam(regs)
+	rawPath, err := getStringParam(pid, pathAddr)
+	if err != nil {
+		// Record the error but continue
+		state.pathParamErr = err
+		return
+	}
+
+	state.dirfd = dirfd
+	state.pathParam = rawPath
+}
+
+func (p *execveatSyscallProcessor) OnReturn(pid int, regs unix.PtraceRegs, state *syscallState) {
+	// If there was an error retrieving the path, skip processing
+	if state.pathParamErr != nil || state.pathParam == "" {
+		return
+	}
+
+	// Like execve, this typically doesn't return on success
+	t, ok := processRegistry.Get(pid)
+
+	if ok && state.pathParam != "" {
+		resolvedPath := t.resolvePath(pid, state.pathParam, state.dirfd)
+		t.fsTracker.AddActivity(resolvedPath, pid, int(p.num), FSActivityTypeExec)
+	}
+}
+
+func (p *execveatSyscallProcessor) EventOnCall() bool {
+	return true
+}
+
+// We now use processRegistry instead of a global map with a mutex
+
+// initSyscallNames initializes the cross-platform syscall names map
+// This is called from the package init function to populate
+// the syscallNames map with syscalls that are common across architectures
+func initSyscallNames() {
+	// No locks needed since this only happens during init
+	// and before any goroutines are started
+
+	// Build our cross-platform syscall name map
+	// using the actual syscall numbers from the unix package
+	// These should work on both architectures
+	syscallNames[unix.SYS_READ] = "read"
+	syscallNames[unix.SYS_WRITE] = "write"
+	syscallNames[unix.SYS_CLOSE] = "close"
+	syscallNames[unix.SYS_FSTAT] = "fstat"
+	syscallNames[unix.SYS_LSEEK] = "lseek"
+	syscallNames[unix.SYS_MMAP] = "mmap"
+	syscallNames[unix.SYS_MPROTECT] = "mprotect"
+	syscallNames[unix.SYS_MUNMAP] = "munmap"
+	syscallNames[unix.SYS_BRK] = "brk"
+	syscallNames[unix.SYS_RT_SIGACTION] = "rt_sigaction"
+	syscallNames[unix.SYS_RT_SIGPROCMASK] = "rt_sigprocmask"
+	syscallNames[unix.SYS_RT_SIGRETURN] = "rt_sigreturn"
+	syscallNames[unix.SYS_IOCTL] = "ioctl"
+	syscallNames[unix.SYS_PREAD64] = "pread64"
+	syscallNames[unix.SYS_PWRITE64] = "pwrite64"
+	syscallNames[unix.SYS_READV] = "readv"
+	syscallNames[unix.SYS_WRITEV] = "writev"
+	// syscallNames[unix.SYS_ACCESS] = "access"
+	// syscallNames[unix.SYS_PIPE] = "pipe"
+	// syscallNames[unix.SYS_SELECT] = "select"
+	syscallNames[unix.SYS_SCHED_YIELD] = "sched_yield"
+	syscallNames[unix.SYS_MREMAP] = "mremap"
+	syscallNames[unix.SYS_MSYNC] = "msync"
+	syscallNames[unix.SYS_MINCORE] = "mincore"
+	syscallNames[unix.SYS_MADVISE] = "madvise"
+	syscallNames[unix.SYS_DUP] = "dup"
+	syscallNames[unix.SYS_NANOSLEEP] = "nanosleep"
+	syscallNames[unix.SYS_GETITIMER] = "getitimer"
+	syscallNames[unix.SYS_SETITIMER] = "setitimer"
+	syscallNames[unix.SYS_GETPID] = "getpid"
+	syscallNames[unix.SYS_SENDFILE] = "sendfile"
+	syscallNames[unix.SYS_SOCKET] = "socket"
+	syscallNames[unix.SYS_CONNECT] = "connect"
+	syscallNames[unix.SYS_ACCEPT] = "accept"
+	syscallNames[unix.SYS_SENDTO] = "sendto"
+	syscallNames[unix.SYS_RECVFROM] = "recvfrom"
+	syscallNames[unix.SYS_SENDMSG] = "sendmsg"
+	syscallNames[unix.SYS_RECVMSG] = "recvmsg"
+	syscallNames[unix.SYS_SHUTDOWN] = "shutdown"
+	syscallNames[unix.SYS_BIND] = "bind"
+	syscallNames[unix.SYS_LISTEN] = "listen"
+	syscallNames[unix.SYS_GETSOCKNAME] = "getsockname"
+	syscallNames[unix.SYS_GETPEERNAME] = "getpeername"
+	syscallNames[unix.SYS_SOCKETPAIR] = "socketpair"
+	syscallNames[unix.SYS_SETSOCKOPT] = "setsockopt"
+	syscallNames[unix.SYS_GETSOCKOPT] = "getsockopt"
+	syscallNames[unix.SYS_CLONE] = "clone"
+	syscallNames[unix.SYS_EXECVE] = "execve"
+	syscallNames[unix.SYS_EXIT] = "exit"
+	syscallNames[unix.SYS_FCNTL] = "fcntl"
+	syscallNames[unix.SYS_FSYNC] = "fsync"
+	syscallNames[unix.SYS_TRUNCATE] = "truncate"
+	syscallNames[unix.SYS_FTRUNCATE] = "ftruncate"
+	// syscallNames[unix.SYS_GETDENTS] = "getdents"
+
+	// AT family syscalls (more modern, work on both architectures)
+	syscallNames[unix.SYS_OPENAT] = "openat"
+	syscallNames[unix.SYS_MKDIRAT] = "mkdirat"
+	syscallNames[unix.SYS_UNLINKAT] = "unlinkat"
+	syscallNames[unix.SYS_RENAMEAT] = "renameat"
+	syscallNames[unix.SYS_RENAMEAT2] = "renameat2"
+	syscallNames[unix.SYS_EXECVEAT] = "execveat"
+	syscallNames[unix.SYS_ACCEPT4] = "accept4"
+
+	// Note: Syscall processors are now registered in registerCommonSyscallProcessors()
+	// to avoid duplicate registration
+}
+
+// Cross-platform init
+func init() {
+	// Everything here runs during init time only, before any goroutines start
+	// so no locking is needed
+	initSyscallNames()
+	registerCommonSyscallProcessors()
+
+	// Note: We're now using processRegistry instead of syscallTracers
+}
+
+// registerCommonSyscallProcessors registers the common syscall processors that are available
+// across all architectures. Architecture-specific processors are registered in their
+// respective architecture initialization files.
+func registerCommonSyscallProcessors() {
+	// Register common syscall processors
+	RegisterSyscallProcessor(&openatSyscallProcessor{
+		baseSyscallProcessor: &baseSyscallProcessor{
+			num:         unix.SYS_OPENAT,
+			name:        "openat",
+			syscallType: OpenFileType,
+		},
+	})
+
+	RegisterSyscallProcessor(&fstatatSyscallProcessor{
+		baseSyscallProcessor: &baseSyscallProcessor{
+			num:         unix.SYS_NEWFSTATAT,
+			name:        "newfstatat",
+			syscallType: CheckFileType,
+		},
+	})
+
+	RegisterSyscallProcessor(&execveSyscallProcessor{
+		baseSyscallProcessor: &baseSyscallProcessor{
+			num:         unix.SYS_EXECVE,
+			name:        "execve",
+			syscallType: ExecType,
+		},
+	})
+
+	RegisterSyscallProcessor(&execveatSyscallProcessor{
+		baseSyscallProcessor: &baseSyscallProcessor{
+			num:         unix.SYS_EXECVEAT,
+			name:        "execveat",
+			syscallType: ExecType,
+		},
+	})
+
+	// Note: Architecture-specific syscalls (like SYS_OPEN and SYS_STAT for amd64)
+	// are registered in their respective arch-specific init functions
+}
+
+// Return human-readable names for system calls
+func getSyscallName(num uint32) string {
+	// No lock needed since syscallNames is read-only after init
+	if name, ok := syscallNames[num]; ok {
+		return name
+	}
+	return fmt.Sprintf("unknown(%d)", num)
+}
+
+// SyscallType represents the type of syscall operation
+type SyscallType string
+
+const (
+	// Types of syscalls
+	CheckFileType SyscallType = "type.checkfile" // Syscalls that check file existence/stats (stat, access, etc.)
+	OpenFileType  SyscallType = "type.openfile"  // Syscalls that open files (open, openat, etc.)
+	ExecType      SyscallType = "type.exec"      // Syscalls that execute processes (execve, execveat)
+	NetworkType   SyscallType = "type.network"   // Syscalls for network operations (socket, connect, etc.)
+	MemoryType    SyscallType = "type.memory"    // Syscalls for memory operations (mmap, etc.)
+	ProcessType   SyscallType = "type.process"   // Syscalls for process operations (fork, etc.)
+	SignalType    SyscallType = "type.signal"    // Syscalls for signal handling
+	TimeType      SyscallType = "type.time"      // Syscalls for time operations
+	SecurityType  SyscallType = "type.security"  // Syscalls for security operations
+	IpcType       SyscallType = "type.ipc"       // Syscalls for IPC operations
+	MiscType      SyscallType = "type.misc"      // Syscalls that don't fit other categories
+)
+
+// SyscallProcessor interfaces define how to process different syscalls
+type SyscallProcessor interface {
+	SyscallNumber() uint32
+	SyscallName() string
+	SyscallType() SyscallType
+	OnCall(pid int, regs unix.PtraceRegs, state *syscallState)
+	OnReturn(pid int, regs unix.PtraceRegs, state *syscallState)
+	EventOnCall() bool
+	OKReturnStatus(retVal uint64) bool
+}
+
+// Base syscall processor implementation with common functionality
+type baseSyscallProcessor struct {
+	num         uint32
+	name        string
+	syscallType SyscallType
+}
+
+func (p *baseSyscallProcessor) SyscallNumber() uint32 {
+	return p.num
+}
+
+func (p *baseSyscallProcessor) SyscallName() string {
+	return p.name
+}
+
+func (p *baseSyscallProcessor) SyscallType() SyscallType {
+	return p.syscallType
+}
+
+func (p *baseSyscallProcessor) EventOnCall() bool {
+	return false
+}
+
+func (p *baseSyscallProcessor) OKReturnStatus(retVal uint64) bool {
+	// Default implementation - success if return value >= 0
+	return int64(retVal) >= 0
+}
+
+// RegisterSyscallProcessor adds a processor for a syscall
+// This should only be called during init time
+func RegisterSyscallProcessor(processor SyscallProcessor) {
+	// No locking needed since this happens during init
+	syscallProcessors[processor.SyscallNumber()] = processor
+}
+
+// GetSyscallProcessor returns the processor for a given syscall, or nil if not found
+func GetSyscallProcessor(syscallNum uint32) SyscallProcessor {
+	// No lock needed since syscallProcessors is read-only after init
+	return syscallProcessors[syscallNum]
+}
+
+// BaseArchHandler provides common functionality for architecture handlers
+type BaseArchHandler struct {
+	fileOps     map[uint32]bool
+	networkOps  map[uint32]bool
+	execOps     map[uint32]bool
+	memoryOps   map[uint32]bool
+	processOps  map[uint32]bool
+	signalOps   map[uint32]bool
+	timeOps     map[uint32]bool
+	securityOps map[uint32]bool
+	ipcOps      map[uint32]bool
+}
+
+// NewBaseArchHandler creates a new base architecture handler
+func NewBaseArchHandler() *BaseArchHandler {
+	return &BaseArchHandler{
+		fileOps:     make(map[uint32]bool),
+		networkOps:  make(map[uint32]bool),
+		execOps:     make(map[uint32]bool),
+		memoryOps:   make(map[uint32]bool),
+		processOps:  make(map[uint32]bool),
+		signalOps:   make(map[uint32]bool),
+		timeOps:     make(map[uint32]bool),
+		securityOps: make(map[uint32]bool),
+		ipcOps:      make(map[uint32]bool),
+	}
+}
+
+// RegisterFileOp registers syscalls as file operations
+func (h *BaseArchHandler) RegisterFileOp(syscalls ...uint32) {
+	for _, num := range syscalls {
+		h.fileOps[num] = true
+	}
+}
+
+// RegisterNetworkOp registers syscalls as network operations
+func (h *BaseArchHandler) RegisterNetworkOp(syscalls ...uint32) {
+	for _, num := range syscalls {
+		h.networkOps[num] = true
+	}
+}
+
+// RegisterExecOp registers syscalls as exec operations
+func (h *BaseArchHandler) RegisterExecOp(syscalls ...uint32) {
+	for _, num := range syscalls {
+		h.execOps[num] = true
+	}
+}
+
+// RegisterMemoryOp registers syscalls as memory operations
+func (h *BaseArchHandler) RegisterMemoryOp(syscalls ...uint32) {
+	for _, num := range syscalls {
+		h.memoryOps[num] = true
+	}
+}
+
+// RegisterProcessOp registers syscalls as process operations
+func (h *BaseArchHandler) RegisterProcessOp(syscalls ...uint32) {
+	for _, num := range syscalls {
+		h.processOps[num] = true
+	}
+}
+
+// RegisterSignalOp registers syscalls as signal operations
+func (h *BaseArchHandler) RegisterSignalOp(syscalls ...uint32) {
+	for _, num := range syscalls {
+		h.signalOps[num] = true
+	}
+}
+
+// RegisterTimeOp registers syscalls as time operations
+func (h *BaseArchHandler) RegisterTimeOp(syscalls ...uint32) {
+	for _, num := range syscalls {
+		h.timeOps[num] = true
+	}
+}
+
+// RegisterSecurityOp registers syscalls as security operations
+func (h *BaseArchHandler) RegisterSecurityOp(syscalls ...uint32) {
+	for _, num := range syscalls {
+		h.securityOps[num] = true
+	}
+}
+
+// RegisterIpcOp registers syscalls as IPC operations
+func (h *BaseArchHandler) RegisterIpcOp(syscalls ...uint32) {
+	for _, num := range syscalls {
+		h.ipcOps[num] = true
+	}
+}
+
+// IsFileOpSyscall returns true if the syscall is a file operation
+func (h *BaseArchHandler) IsFileOpSyscall(num uint32) bool {
+	return h.fileOps[num]
+}
+
+// IsNetworkSyscall returns true if the syscall is a network operation
+func (h *BaseArchHandler) IsNetworkSyscall(num uint32) bool {
+	return h.networkOps[num]
+}
+
+// IsExecSyscall returns true if the syscall is an exec operation
+func (h *BaseArchHandler) IsExecSyscall(num uint32) bool {
+	return h.execOps[num]
+}
+
+// IsMemorySyscall returns true if the syscall is a memory operation
+func (h *BaseArchHandler) IsMemorySyscall(num uint32) bool {
+	return h.memoryOps[num]
+}
+
+// IsProcessSyscall returns true if the syscall is a process operation
+func (h *BaseArchHandler) IsProcessSyscall(num uint32) bool {
+	return h.processOps[num]
+}
+
+// IsSignalSyscall returns true if the syscall is a signal operation
+func (h *BaseArchHandler) IsSignalSyscall(num uint32) bool {
+	return h.signalOps[num]
+}
+
+// IsTimeSyscall returns true if the syscall is a time operation
+func (h *BaseArchHandler) IsTimeSyscall(num uint32) bool {
+	return h.timeOps[num]
+}
+
+// IsSecuritySyscall returns true if the syscall is a security operation
+func (h *BaseArchHandler) IsSecuritySyscall(num uint32) bool {
+	return h.securityOps[num]
+}
+
+// IsIpcSyscall returns true if the syscall is an IPC operation
+func (h *BaseArchHandler) IsIpcSyscall(num uint32) bool {
+	return h.ipcOps[num]
+}
+
+// ArchHandler defines an interface for architecture-specific operations
+// This interface will be implemented in the arch-specific files
+type ArchHandler interface {
+	// Register operations
+	CallFirstParam(regs unix.PtraceRegs) uint64
+	CallSecondParam(regs unix.PtraceRegs) uint64
+	CallThirdParam(regs unix.PtraceRegs) uint64
+	CallFourthParam(regs unix.PtraceRegs) uint64
+	CallFifthParam(regs unix.PtraceRegs) uint64
+	CallSixthParam(regs unix.PtraceRegs) uint64
+	CallReturnValue(regs unix.PtraceRegs) uint64
+
+	// System call operations
+	GetSyscallNumber(regs unix.PtraceRegs) uint32
+
+	// Architecture-specific classification
+	IsFileOpSyscall(num uint32) bool
+	IsNetworkSyscall(num uint32) bool
+	IsExecSyscall(num uint32) bool
+	IsMemorySyscall(num uint32) bool
+	IsProcessSyscall(num uint32) bool
+	IsSignalSyscall(num uint32) bool
+	IsTimeSyscall(num uint32) bool
+	IsSecuritySyscall(num uint32) bool
+	IsIpcSyscall(num uint32) bool
+
+	// Architecture name for logging
+	Name() string
+}
+
+// Architecture-specific handler is set at init time
+var archHandler ArchHandler
+
+// Wrapper functions for syscall classification
+// These delegate to the architecture-specific handler
+
+// IsFileOpSyscall checks if a syscall is related to file operations
+func IsFileOpSyscall(num uint32) bool {
+	return archHandler.IsFileOpSyscall(num)
+}
+
+// IsNetworkSyscall checks if a syscall is related to network operations
+func IsNetworkSyscall(num uint32) bool {
+	return archHandler.IsNetworkSyscall(num)
+}
+
+// IsExecSyscall checks if a syscall is related to process execution
+func IsExecSyscall(num uint32) bool {
+	return archHandler.IsExecSyscall(num)
+}
+
+// IsMemorySyscall checks if a syscall is related to memory management
+func IsMemorySyscall(num uint32) bool {
+	return archHandler.IsMemorySyscall(num)
+}
+
+// IsProcessSyscall checks if a syscall is related to process management (non-exec)
+func IsProcessSyscall(num uint32) bool {
+	return archHandler.IsProcessSyscall(num)
+}
+
+// IsSignalSyscall checks if a syscall is related to signal handling
+func IsSignalSyscall(num uint32) bool {
+	return archHandler.IsSignalSyscall(num)
+}
+
+// IsTimeSyscall checks if a syscall is related to time operations
+func IsTimeSyscall(num uint32) bool {
+	return archHandler.IsTimeSyscall(num)
+}
+
+// IsSecuritySyscall checks if a syscall is related to security operations
+func IsSecuritySyscall(num uint32) bool {
+	return archHandler.IsSecuritySyscall(num)
+}
+
+// IsIpcSyscall checks if a syscall is related to inter-process communication
+func IsIpcSyscall(num uint32) bool {
+	return archHandler.IsIpcSyscall(num)
+}
+
+// GetSyscallType returns the type of syscall based on classification functions
+func GetSyscallType(syscallNum uint32) SyscallType {
+	// Check for specific processor first
+	if processor := GetSyscallProcessor(syscallNum); processor != nil {
+		return processor.SyscallType()
+	}
+
+	// Otherwise use the general classification functions
+	switch {
+	case IsFileOpSyscall(syscallNum):
+		// Further classify file ops
+		// This is a simplified check - ideally we'd have a more comprehensive classification
+		for _, openSyscall := range []uint32{unix.SYS_OPENAT} {
+			if syscallNum == openSyscall {
+				return OpenFileType
+			}
+		}
+		return CheckFileType
+	case IsExecSyscall(syscallNum):
+		return ExecType
+	case IsNetworkSyscall(syscallNum):
+		return NetworkType
+	case IsMemorySyscall(syscallNum):
+		return MemoryType
+	case IsProcessSyscall(syscallNum):
+		return ProcessType
+	case IsSignalSyscall(syscallNum):
+		return SignalType
+	case IsTimeSyscall(syscallNum):
+		return TimeType
+	case IsSecuritySyscall(syscallNum):
+		return SecurityType
+	case IsIpcSyscall(syscallNum):
+		return IpcType
+	default:
+		return MiscType
+	}
+}

--- a/tw/pkg/commands/ptrace/tracer.go
+++ b/tw/pkg/commands/ptrace/tracer.go
@@ -4,1625 +4,797 @@
 package ptrace
 
 import (
-	"bytes"
 	"context"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
-	"path/filepath"
 	"runtime"
 	"strings"
 	"sync"
 	"syscall"
-	"time"
 
 	"github.com/armon/go-radix"
-	"github.com/chainguard-dev/clog"
 	"golang.org/x/sys/unix"
 )
 
-// AT_FDCWD is the "current working directory" file descriptor
-const AT_FDCWD = -100
-
-// handleSyscall is a shared implementation for handling syscalls across
-// architectures
-func handleSyscall(t *Tracer, pid int) {
-	// Register this tracer for this PID before we access registers
-	// This ensures other threads know we're handling this PID
-	processRegistry.Set(pid, t)
-
-	// Try to get the registers with better error handling
-	var regs unix.PtraceRegs
-	if err := unix.PtraceGetRegs(pid, &regs); err != nil {
-		clog.Debugf("Failed to get registers for PID %d: %v", pid, err)
-
-		// Handle common errors specially
-		if strings.Contains(err.Error(), "no such process") {
-			// Process terminated while we were handling it
-			clog.Infof("Process %d no longer exists, cleaning up", pid)
-			t.statesMu.Lock()
-			delete(t.states, pid)
-			t.statesMu.Unlock()
-
-			processRegistry.Delete(pid)
-
-			select {
-			case t.events <- Event{
-				Type: EventExit,
-				Pid:  pid,
-				Path: fmt.Sprintf("process %d terminated", pid),
-			}:
-				clog.Debugf("sent termination event for %d", pid)
-			default:
-				clog.Warnf("Event channel full, dropping termination event for pid=%d", pid)
-			}
-		} else {
-			// For other errors, try to continue the process to avoid hanging
-			if err := unix.PtraceSyscall(pid, 0); err != nil {
-				// If this also fails with "no such process", the process is gone
-				if strings.Contains(err.Error(), "no such process") {
-					clog.Infof("Process %d terminated during error handling, cleaning up", pid)
-					t.statesMu.Lock()
-					delete(t.states, pid)
-					t.statesMu.Unlock()
-					processRegistry.Delete(pid)
-				} else {
-					clog.Warnf("Failed to continue process after register error: %v", err)
-				}
-			}
-		}
-		return
-	}
-
-	// Use the architecture handler to get the syscall number
-	syscallNum := archHandler.GetSyscallNumber(regs)
-
-	// Get syscall name (doesn't require locking the state)
-	syscallName := getSyscallName(syscallNum)
-
-	// We already registered this tracer for this PID when we called processRegistry.Set
-
-	clog.Debugf("SYSCALL: %s | syscallNum: %d | pid: %d", syscallName, syscallNum, pid)
-
-	// Get processor for this syscall if available
-	processor := GetSyscallProcessor(syscallNum)
-
-	// Acquire state lock to access the pid's state
-	t.statesMu.Lock()
-
-	// Make sure we have a state for this PID
-	state, exists := t.states[pid]
-	if !exists {
-		// Create new state for this PID since it doesn't exist
-		state = &syscallState{
-			pid:          pid,
-			callNum:      syscallNum,
-			expectReturn: true,
-			gotCallNum:   true,
-			fdTable:      make(map[int]FD),
-			childPids:    make(map[int]bool),
-			startTime:    time.Now(),
-		}
-		t.states[pid] = state
-		clog.Debugf("Created new state for PID %d", pid)
-		t.statesMu.Unlock()
-
-		// Handle syscall entry for a new process
-		if processor != nil {
-			clog.Debugf("Calling OnCall for %s (syscallNum=%d) pid=%d",
-				processor.SyscallName(), syscallNum, pid)
-
-			// Make a copy to work with
-			stateCopy := *state
-			processor.OnCall(pid, regs, &stateCopy)
-
-			// Update state with processor results
-			t.statesMu.Lock()
-			if state, ok := t.states[pid]; ok {
-				state.pathParam = stateCopy.pathParam
-				state.pathParamErr = stateCopy.pathParamErr
-				state.dirfd = stateCopy.dirfd
-			}
-
-			// Get values needed for event before releasing lock
-			var eventPath string
-			var dirfd int
-			if st, ok := t.states[pid]; ok {
-				eventPath = st.pathParam
-				dirfd = st.dirfd
-			}
-			t.statesMu.Unlock()
-
-			// Generate event for syscalls that do this on call rather than return
-			if processor.EventOnCall() {
-				if dirfd != 0 && dirfd != AT_FDCWD {
-					eventPath = t.resolvePath(pid, eventPath, dirfd)
-				}
-
-				// Send event non-blocking to avoid deadlocks
-				select {
-				case t.events <- Event{
-					Type:        EventSyscall,
-					Syscall:     syscallNum,
-					SyscallName: syscallName,
-					Pid:         pid,
-					Path:        eventPath,
-				}:
-					// Event sent successfully
-					clog.Debugf("Sent event for %s (pid=%d)", syscallName, pid)
-				default:
-					// Channel is full, log warning and continue
-					clog.Warnf("Event channel full, dropping event for syscall %s", syscallName)
-				}
-			}
-		} else {
-			// Re-acquire lock for the fallback handler
-			t.statesMu.Lock()
-			if st, ok := t.states[pid]; ok {
-				state = st
-			}
-			t.statesMu.Unlock()
-
-			// Fallback for syscalls without processors
-			handleSyscallEnter(t, pid, syscallNum, syscallName, regs, state)
-		}
-	} else if state.expectReturn {
-		// This is syscall exit
-		retVal := archHandler.CallReturnValue(regs)
-
-		// Update state for syscall return
-		state.retVal = retVal
-		state.gotRetVal = true
-
-		// Make copies of needed values before modifying state
-		eventPath := state.pathParam
-		dirfd := state.dirfd
-		callNum := state.callNum
-		pathParamErr := state.pathParamErr
-
-		// Reset state for next syscall
-		state.expectReturn = false
-		state.callNum = 0
-		state.pathParam = ""
-		state.pathParamErr = nil
-		state.dirfd = 0
-
-		// Release lock after updating state
-		t.statesMu.Unlock()
-
-		// Handle syscall exit
-		if processor != nil {
-			clog.Debugf("Calling OnReturn for %s (syscallNum=%d) pid=%d",
-				processor.SyscallName(), syscallNum, pid)
-
-			// Create a working copy with needed values restored
-			stateCopy := syscallState{
-				pid:          pid,
-				callNum:      callNum,
-				retVal:       retVal,
-				gotRetVal:    true,
-				pathParam:    eventPath,
-				pathParamErr: pathParamErr,
-				dirfd:        dirfd,
-				fdTable:      make(map[int]FD), // Create a new map to avoid modifying the original
-			}
-
-			// Copy relevant parts of fdTable if needed by processor
-			t.statesMu.RLock()
-			if st, ok := t.states[pid]; ok {
-				for k, v := range st.fdTable {
-					stateCopy.fdTable[k] = v
-				}
-			}
-			t.statesMu.RUnlock()
-
-			// Call processor with our copy
-			processor.OnReturn(pid, regs, &stateCopy)
-
-			// Send event if needed
-			if !processor.EventOnCall() && pathParamErr == nil {
-				if dirfd != 0 && dirfd != AT_FDCWD {
-					eventPath = t.resolvePath(pid, eventPath, dirfd)
-				}
-
-				// Non-blocking send to avoid deadlocks
-				select {
-				case t.events <- Event{
-					Type:        EventSyscall,
-					Syscall:     callNum,
-					SyscallName: syscallName + "-return",
-					Pid:         pid,
-					Path:        eventPath,
-					ReturnVal:   int64(retVal),
-				}:
-					// Event sent successfully
-					clog.Debugf("Sent return event for %s (pid=%d)", syscallName, pid)
-				default:
-					// Channel is full, log warning and continue
-					clog.Warnf("Event channel full, dropping return event for syscall %s", syscallName)
-				}
-			}
-
-			// Check if processor updated fdTable and merge changes back if needed
-			// This avoids losing file descriptor information
-			t.statesMu.Lock()
-			if st, ok := t.states[pid]; ok {
-				// Merge any new fds processor might have added
-				for fdNum, fdInfo := range stateCopy.fdTable {
-					if _, exists := st.fdTable[fdNum]; !exists {
-						st.fdTable[fdNum] = fdInfo
-					}
-				}
-			}
-			t.statesMu.Unlock()
-		} else {
-			// Get a fresh copy of state for the fallback handler
-			t.statesMu.Lock()
-			if st, ok := t.states[pid]; ok {
-				// Restore needed values in the state
-				st.callNum = callNum
-				st.retVal = retVal
-				st.gotRetVal = true
-				state = st
-			}
-			t.statesMu.Unlock()
-
-			// Fallback for syscalls without processors
-			handleSyscallExit(t, pid, regs, state, syscallName)
-		}
-	} else {
-		// This is a new syscall after a completed one
-		state.callNum = syscallNum
-		state.expectReturn = true
-		state.gotCallNum = true
-		state.gotRetVal = false
-		t.statesMu.Unlock()
-
-		// Call recursively to handle the new syscall
-		// This is safe because we updated the state before releasing the lock
-		handleSyscall(t, pid)
-	}
+// SyscallState tracks the state of a syscall for a specific pid
+type SyscallState struct {
+	pid          int    // Process ID
+	callNum      uint64 // Syscall number
+	retVal       uint64 // Return value
+	expectReturn bool   // Whether we're expecting a return from this syscall
+	gotCallNum   bool   // Whether we've captured the syscall number
+	gotRetVal    bool   // Whether we've captured the return value
+	started      bool   // Whether the process has started
+	exiting      bool   // Whether the process is exiting
+	terminated   bool   // Whether the process has terminated
+	parent       int    // Parent PID
+	children     []int  // Child PIDs spawned by this process
+	cmdline      string // Command line of the process (executable path)
+	pathParam    string // Path parameter extracted from the syscall
 }
 
-// handleSyscallEnter handles the common syscall entry logic
-func handleSyscallEnter(t *Tracer, pid int, syscallNum uint32, syscallName string, regs unix.PtraceRegs, state *syscallState) {
-	// Function to safely send events with non-blocking behavior
-	sendEvent := func(event Event) {
-		select {
-		case t.events <- event:
-			// Event sent successfully
-			clog.Debugf("Sent event for %s (pid=%d)", event.SyscallName, event.Pid)
-		default:
-			// Channel is full, log warning and continue
-			clog.Warnf("Event channel full, dropping event for syscall %s", event.SyscallName)
-		}
-	}
-
-	switch syscallNum {
-	case unix.SYS_READ, unix.SYS_PREAD64:
-		fd := archHandler.CallFirstParam(regs)
-		bufSize := archHandler.CallThirdParam(regs)
-
-		// Try to get the file path associated with this fd
-		path := fmt.Sprintf("fd: %d", fd)
-
-		// Create a safe copy of the fdTable to avoid locking during event processing
-		fdPath := ""
-		t.statesMu.RLock()
-		if state != nil {
-			if fdInfo, ok := state.fdTable[int(fd)]; ok {
-				fdPath = fdInfo.Path
-			}
-		}
-		t.statesMu.RUnlock()
-
-		if fdPath != "" {
-			path = fmt.Sprintf("fd: %d (%s)", fd, fdPath)
-		}
-
-		sendEvent(Event{
-			Type:        EventSyscall,
-			Syscall:     syscallNum,
-			SyscallName: syscallName,
-			Pid:         pid,
-			Path:        fmt.Sprintf("%s, size: %d bytes", path, bufSize),
-		})
-
-	case unix.SYS_WRITE, unix.SYS_PWRITE64:
-		fd := archHandler.CallFirstParam(regs)
-		bufSize := archHandler.CallThirdParam(regs)
-
-		// Try to get the file path associated with this fd
-		path := fmt.Sprintf("fd: %d", fd)
-
-		// Get FD info safely
-		fdPath := ""
-		t.statesMu.RLock()
-		if state != nil && state.fdTable != nil {
-			if fdInfo, ok := state.fdTable[int(fd)]; ok {
-				fdPath = fdInfo.Path
-			}
-		}
-		t.statesMu.RUnlock()
-
-		if fdPath != "" {
-			path = fmt.Sprintf("fd: %d (%s)", fd, fdPath)
-		}
-
-		sendEvent(Event{
-			Type:        EventSyscall,
-			Syscall:     syscallNum,
-			SyscallName: syscallName,
-			Pid:         pid,
-			Path:        fmt.Sprintf("%s, size: %d bytes", path, bufSize),
-		})
-
-	case unix.SYS_CLOSE:
-		fd := archHandler.CallFirstParam(regs)
-
-		// Try to get the file path associated with this fd
-		path := fmt.Sprintf("fd: %d", fd)
-		fdPath := ""
-
-		t.statesMu.Lock()
-		if state != nil && state.fdTable != nil {
-			if fdInfo, ok := state.fdTable[int(fd)]; ok {
-				fdPath = fdInfo.Path
-				// Store the fd being closed for use in return
-				state.pathParam = fdInfo.Path
-			}
-		}
-		t.statesMu.Unlock()
-
-		if fdPath != "" {
-			path = fmt.Sprintf("fd: %d (%s)", fd, fdPath)
-		}
-
-		sendEvent(Event{
-			Type:        EventSyscall,
-			Syscall:     syscallNum,
-			SyscallName: syscallName,
-			Pid:         pid,
-			Path:        path,
-		})
-
-	case unix.SYS_SOCKET, unix.SYS_CONNECT, unix.SYS_BIND, unix.SYS_LISTEN:
-		domain := archHandler.CallFirstParam(regs)
-		sockType := archHandler.CallSecondParam(regs)
-		protocol := archHandler.CallThirdParam(regs)
-
-		sendEvent(Event{
-			Type:        EventSyscall,
-			Syscall:     syscallNum,
-			SyscallName: syscallName,
-			Pid:         pid,
-			Path:        fmt.Sprintf("domain: %d, type: %d, protocol: %d", domain, sockType, protocol),
-		})
-
-	case unix.SYS_ACCEPT, unix.SYS_ACCEPT4:
-		sockfd := archHandler.CallFirstParam(regs)
-
-		sendEvent(Event{
-			Type:        EventSyscall,
-			Syscall:     syscallNum,
-			SyscallName: syscallName,
-			Pid:         pid,
-			Path:        fmt.Sprintf("sockfd: %d", sockfd),
-		})
-
-	case unix.SYS_MMAP:
-		length := archHandler.CallSecondParam(regs)
-		prot := archHandler.CallThirdParam(regs)
-		flags := archHandler.CallFourthParam(regs)
-
-		sendEvent(Event{
-			Type:        EventSyscall,
-			Syscall:     syscallNum,
-			SyscallName: syscallName,
-			Pid:         pid,
-			Path:        fmt.Sprintf("length: %d, prot: 0x%x, flags: 0x%x", length, prot, flags),
-		})
-
-	case unix.SYS_CHDIR:
-		pathAddr := archHandler.CallFirstParam(regs)
-		if path, err := getStringParam(pid, pathAddr); err == nil && path != "" {
-			// Update state in a single lock acquisition
-			t.statesMu.Lock()
-			if state != nil {
-				state.pathParam = path
-
-				// Update the process's current working directory
-				if filepath.IsAbs(path) {
-					state.cwd = path
-				} else {
-					// Make sure cwd is initialized
-					if state.cwd == "" {
-						// Try to get cwd from /proc if available
-						if cwd, err := os.Readlink(fmt.Sprintf("/proc/%d/cwd", pid)); err == nil {
-							state.cwd = cwd
-						} else {
-							// Default to current directory
-							if wd, err := os.Getwd(); err == nil {
-								state.cwd = wd
-							} else {
-								state.cwd = "/"
-							}
-						}
-					}
-					state.cwd = filepath.Clean(filepath.Join(state.cwd, path))
-				}
-			}
-			t.statesMu.Unlock()
-
-			sendEvent(Event{
-				Type:        EventSyscall,
-				Syscall:     syscallNum,
-				SyscallName: syscallName,
-				Pid:         pid,
-				Path:        path,
-			})
-		}
-	}
-}
-
-// handleSyscallExit handles the common syscall exit logic
-func handleSyscallExit(t *Tracer, pid int, regs unix.PtraceRegs, state *syscallState, syscallName string) {
-	// Function to safely send events with non-blocking behavior
-	sendEvent := func(event Event) {
-		select {
-		case t.events <- event:
-			// Event sent successfully
-			clog.Debugf("Sent return event for %s (pid=%d)", event.SyscallName, event.Pid)
-		default:
-			// Channel is full, log warning and continue
-			clog.Warnf("Event channel full, dropping return event for syscall %s", event.SyscallName)
-		}
-	}
-
-	// Safely get values we need from state
-	var callNum uint32
-	var pathParam string
-
-	// We need to be careful as state could be null if process terminated
-	if state != nil {
-		t.statesMu.RLock()
-		callNum = state.callNum
-		pathParam = state.pathParam
-		t.statesMu.RUnlock()
-	} else {
-		// If state is null, use syscall number from regs
-		callNum = archHandler.GetSyscallNumber(regs)
-	}
-
-	retVal := archHandler.CallReturnValue(regs)
-	sretVal := int64(retVal)
-
-	switch callNum {
-	case unix.SYS_READ, unix.SYS_PREAD64, unix.SYS_WRITE, unix.SYS_PWRITE64:
-		if sretVal >= 0 {
-			sendEvent(Event{
-				Type:        EventSyscall,
-				Syscall:     callNum,
-				SyscallName: getSyscallName(callNum) + "-return",
-				Pid:         pid,
-				Path:        fmt.Sprintf("returned %d bytes", sretVal),
-				ReturnVal:   sretVal,
-			})
-		} else {
-			sendEvent(Event{
-				Type:        EventSyscall,
-				Syscall:     callNum,
-				SyscallName: getSyscallName(callNum) + "-return",
-				Pid:         pid,
-				Path:        fmt.Sprintf("error: %d", -sretVal),
-				ReturnVal:   sretVal,
-			})
-		}
-
-	case unix.SYS_CLOSE:
-		fdVal := archHandler.CallFirstParam(regs)
-		// Remove from file descriptor table if successful
-		if sretVal == 0 && pathParam != "" && state != nil {
-			t.statesMu.Lock()
-			if state.fdTable != nil {
-				delete(state.fdTable, int(fdVal))
-			}
-			t.statesMu.Unlock()
-		}
-
-		sendEvent(Event{
-			Type:        EventSyscall,
-			Syscall:     callNum,
-			SyscallName: getSyscallName(callNum) + "-return",
-			Pid:         pid,
-			Path:        fmt.Sprintf("returned %d", sretVal),
-			ReturnVal:   sretVal,
-		})
-
-	case unix.SYS_CONNECT, unix.SYS_BIND, unix.SYS_SOCKET:
-		if sretVal >= 0 {
-			// For socket() specifically, add the file descriptor
-			if callNum == unix.SYS_SOCKET {
-				t.statesMu.Lock()
-				if state != nil && state.fdTable != nil {
-					state.fdTable[int(sretVal)] = FD{
-						Path:     fmt.Sprintf("<socket:%d>", sretVal),
-						Type:     "socket",
-						OpenTime: time.Now(),
-					}
-				}
-				t.statesMu.Unlock()
-			}
-
-			sendEvent(Event{
-				Type:        EventSyscall,
-				Syscall:     callNum,
-				SyscallName: getSyscallName(callNum) + "-return",
-				Pid:         pid,
-				Path:        fmt.Sprintf("success: fd %d", sretVal),
-				ReturnVal:   sretVal,
-			})
-		} else {
-			sendEvent(Event{
-				Type:        EventSyscall,
-				Syscall:     callNum,
-				SyscallName: getSyscallName(callNum) + "-return",
-				Pid:         pid,
-				Path:        fmt.Sprintf("error: %d", -sretVal),
-				ReturnVal:   sretVal,
-			})
-		}
-
-	case unix.SYS_DUP, unix.SYS_DUP3:
-		// Handle file descriptor duplication
-		if sretVal >= 0 {
-			// Get the source fd
-			srcFd := int(archHandler.CallFirstParam(regs))
-			newFd := int(sretVal)
-
-			// Copy file descriptor info if available
-			t.statesMu.Lock()
-			if state != nil && state.fdTable != nil {
-				if srcFdInfo, ok := state.fdTable[srcFd]; ok {
-					state.fdTable[newFd] = FD{
-						Path:     srcFdInfo.Path,
-						Type:     srcFdInfo.Type,
-						OpenTime: time.Now(),
-					}
-				}
-			}
-			t.statesMu.Unlock()
-
-			sendEvent(Event{
-				Type:        EventSyscall,
-				Syscall:     callNum,
-				SyscallName: getSyscallName(callNum) + "-return",
-				Pid:         pid,
-				Path:        fmt.Sprintf("dup %d -> %d", srcFd, newFd),
-				ReturnVal:   sretVal,
-			})
-		}
-	}
-}
-
-type Event struct {
-	Type        EventType
-	Syscall     uint32
-	SyscallName string
-	Pid         int
-	Path        string
-	ReturnVal   int64
-}
-
+// SyscallEvent represents a fully traced syscall event with call and return
 type SyscallEvent struct {
-	Regs     unix.PtraceRegs
-	Sysno    int
-	Args     SyscallArgument
-	Ret      [2]SyscallArgument
-	Errno    unix.Errno
-	Duration time.Duration
+	returned  bool   // Whether this includes the return value
+	pid       int    // Process ID
+	callNum   uint32 // Syscall number
+	retVal    uint64 // Return value
+	pathParam string // Path parameter extracted from the syscall
 }
 
-type SyscallArguments [6]SyscallArgument
-
-type SyscallArgument struct {
-	Value uintptr
-}
-
-type EventType int
-
-const (
-	EventSyscall EventType = iota
-	EventFork
-	EventExec
-	EventExit
-)
-
-// FSActivity represents information about file system activity
-type FSActivity struct {
-	Ops           int              // Total operations on this path
-	OpsRead       int              // Read operations
-	OpsWrite      int              // Write operations
-	OpsExec       int              // Execution operations
-	OpsCheckFile  int              // File check operations (stat, access, etc.)
-	OpsOpenFile   int              // File open operations
-	Pids          map[int]struct{} // Set of PIDs that accessed this path
-	Syscalls      map[int]struct{} // Set of syscalls used to access this path
-	IsSubdir      bool             // Whether this path is a subdirectory of another tracked path
-	LastOperation time.Time        // Last time this path was accessed
-}
-
-// FSActivityType categorizes the types of file system operations
-type FSActivityType string
-
-const (
-	// Operation type constants
-	FSActivityTypeRead      FSActivityType = "read"
-	FSActivityTypeWrite     FSActivityType = "write"
-	FSActivityTypeExec      FSActivityType = "exec"
-	FSActivityTypeCheckFile FSActivityType = "check"
-	FSActivityTypeOpenFile  FSActivityType = "open"
-)
-
-// FSActivityTracker tracks file system activity using a radix tree for efficient
-// path-based lookups and prefix searching
-type FSActivityTracker struct {
-	tree         *radix.Tree
-	includeNew   bool                // Whether to include new paths not in origPaths
-	origPaths    map[string]struct{} // Original paths to track
-	skipPrefixes []string            // Path prefixes to skip (e.g., /proc/, /sys/, /dev/)
-	mu           sync.RWMutex        // For thread-safe access to the tree
-}
-
-// NewFSActivityTracker creates a new file system activity tracker
-func NewFSActivityTracker() *FSActivityTracker {
-	return &FSActivityTracker{
-		tree:         radix.New(),
-		includeNew:   true, // Default to including all paths
-		origPaths:    make(map[string]struct{}),
-		skipPrefixes: []string{"/proc/", "/sys/", "/dev/"},
-	}
-}
-
-// SetPathFiltering configures whether to include only original paths or all new paths
-func (f *FSActivityTracker) SetPathFiltering(includeNew bool, origPaths map[string]struct{}) {
-	f.mu.Lock()
-	defer f.mu.Unlock()
-
-	f.includeNew = includeNew
-	f.origPaths = origPaths
-}
-
-// ShouldTrackPath determines if a path should be tracked based on filtering rules
-func (f *FSActivityTracker) ShouldTrackPath(path string) bool {
-	// Skip if path is in skip prefixes
-	for _, prefix := range f.skipPrefixes {
-		if strings.HasPrefix(path, prefix) {
-			return false
-		}
-	}
-
-	// Skip "." since it's not useful
-	if path == "." {
-		return false
-	}
-
-	// If including all new paths, accept all non-skipped paths
-	if f.includeNew {
-		return true
-	}
-
-	// Otherwise, check if it's in original paths
-	f.mu.RLock()
-	_, ok := f.origPaths[path]
-	f.mu.RUnlock()
-	return ok
-}
-
-// AddActivity records file system activity for a path
-func (f *FSActivityTracker) AddActivity(path string, pid int, syscallNum int, opType FSActivityType) {
-	// Clean and normalize the path
-	path = filepath.Clean(path)
-
-	// Check if we should track this path
-	if !f.ShouldTrackPath(path) {
-		return
-	}
-
-	f.mu.Lock()
-	defer f.mu.Unlock()
-
-	// Get or create activity record
-	raw, found := f.tree.Get(path)
-	var activity *FSActivity
-	if !found {
-		activity = &FSActivity{
-			Pids:     make(map[int]struct{}),
-			Syscalls: make(map[int]struct{}),
-		}
-	} else {
-		activity = raw.(*FSActivity)
-	}
-
-	// Update activity information
-	activity.Ops++
-	activity.Pids[pid] = struct{}{}
-	activity.Syscalls[syscallNum] = struct{}{}
-	activity.LastOperation = time.Now()
-
-	// Update operation type counts
-	switch opType {
-	case FSActivityTypeRead:
-		activity.OpsRead++
-	case FSActivityTypeWrite:
-		activity.OpsWrite++
-	case FSActivityTypeExec:
-		activity.OpsExec++
-	case FSActivityTypeCheckFile:
-		activity.OpsCheckFile++
-	case FSActivityTypeOpenFile:
-		activity.OpsOpenFile++
-	}
-
-	// Store the updated activity
-	f.tree.Insert(path, activity)
-}
-
-// GetActivityMap returns a map of all file system activity
-// with subdirectory information calculated, filtering out subdirectories
-func (f *FSActivityTracker) GetActivityMap() map[string]*FSActivity {
-	f.mu.RLock()
-	defer f.mu.RUnlock()
-
-	// Mark subdirectories
-	f.tree.Walk(func(key string, value interface{}) bool {
-		value.(*FSActivity).IsSubdir = false // Reset first
-
-		// Check if this key is a prefix of any other keys
-		f.tree.WalkPrefix(key, func(subkey string, subvalue interface{}) bool {
-			if subkey != key && filepath.Dir(subkey) == key {
-				subvalue.(*FSActivity).IsSubdir = true
-			}
-			return false
-		})
-		return false
-	})
-
-	// Build the result map, excluding subdirectories
-	result := make(map[string]*FSActivity)
-	f.tree.Walk(func(key string, value interface{}) bool {
-		activity := value.(*FSActivity)
-		if !activity.IsSubdir {
-			result[key] = activity
-		}
-		return false
-	})
-
-	return result
-}
-
+// Tracer provides syscall tracing functionality for processes
 type Tracer struct {
-	args            []string
-	cmd             *exec.Cmd
-	events          chan Event
-	done            chan struct{}
-	running         bool
-	statesMu        sync.RWMutex
-	states          map[int]*syscallState
-	fsTracker       *FSActivityTracker
-	opts            TracerOpts
-	collectorDoneCh chan int
+	cmd           *exec.Cmd                  // Command to run and trace
+	args          []string                   // Command arguments
+	pgid          int                        // Process group ID
+	syscallStats  map[uint32]uint64          // Statistics for each syscall
+	fsActivity    map[string]*FSActivityInfo // File system activity
+	eventCh       chan SyscallEvent          // Channel for syscall events
+	done          chan struct{}              // Simple signal channel for completion
+	result        chan TraceResult           // Channel for returning trace results
+	ctx           context.Context            // Context for cancellation
+	signalCh      chan os.Signal             // Channel for receiving signals
+	pidSyscallMap map[int]*SyscallState      // Map of process IDs to syscall states
+	handlers      map[int]SyscallHandler     // Syscall handlers by syscall number
+	stdout        io.Writer                  // Standard output for the traced command
+	stderr        io.Writer                  // Standard error for the traced command
+	mu            sync.Mutex                 // Mutex for protecting shared data
 }
 
+// TraceResult represents the result of a trace operation
+type TraceResult struct {
+	ExitCode int
+	Err      error
+}
+
+// FSActivityInfo tracks file system access information
+type FSActivityInfo struct {
+	OpsAll       uint64           // Total operations on this file/path
+	OpsCheckFile uint64           // Operations that check file existence
+	Pids         map[int]struct{} // Set of PIDs that accessed this path
+	Syscalls     map[int]struct{} // Set of syscalls that accessed this path
+}
+
+// TracerOpts configures the tracer
 type TracerOpts struct {
-	Name string
-	Args []string
+	Args        []string       // Command and arguments to trace
+	ShowDetails bool           // Whether to show detailed output
+	Filter      []string       // Syscalls to filter (if empty, trace all)
+	Stdout      io.Writer      // Standard output destination
+	Stderr      io.Writer      // Standard error destination
+	SignalCh    chan os.Signal // Channel for receiving external signals
 }
 
-// GetFileSystemActivity returns the file system activity tracked by this tracer
-func (t *Tracer) GetFileSystemActivity() map[string]*FSActivity {
-	return t.fsTracker.GetActivityMap()
+// SyscallHandler defines interface for handling different types of syscalls
+type SyscallHandler interface {
+	// SyscallNumber returns the syscall number this handler is responsible for
+	SyscallNumber() int
+
+	// SyscallName returns the human-readable name of the syscall
+	SyscallName() string
+
+	// SyscallType returns the type of syscall (check file, open file, exec, etc.)
+	SyscallType() SyscallType
+
+	// OnCall processes a syscall entry, extracting relevant information
+	// from registers and updating the syscall state
+	OnCall(pid int, regs syscall.PtraceRegs, state *SyscallState)
+
+	// OnReturn processes a syscall exit, handling the return value
+	// and updating the syscall state
+	OnReturn(pid int, regs syscall.PtraceRegs, state *SyscallState)
+
+	// OKReturnStatus determines if a return value indicates success
+	// This varies by syscall type (e.g., open returns fd, stat returns 0 for success)
+	OKReturnStatus(retVal uint64) bool
 }
 
-func New(args []string, opts TracerOpts) (*Tracer, error) {
-	return &Tracer{
-		args:            args,
-		events:          make(chan Event, 10000),
-		done:            make(chan struct{}),
-		running:         false,
-		states:          make(map[int]*syscallState),
-		fsTracker:       NewFSActivityTracker(),
-		collectorDoneCh: make(chan int, 2),
-		opts:            opts,
-	}, nil
+const ptOptions = syscall.PTRACE_O_TRACECLONE |
+	syscall.PTRACE_O_TRACEFORK |
+	syscall.PTRACE_O_TRACEVFORK |
+	syscall.PTRACE_O_TRACEEXEC |
+	syscall.PTRACE_O_TRACESYSGOOD |
+	syscall.PTRACE_O_TRACEEXIT |
+	unix.PTRACE_O_EXITKILL
+
+// New creates a new tracer instance to trace the specified command
+func New(command []string, opts TracerOpts) (*Tracer, error) {
+	if len(command) == 0 {
+		return nil, fmt.Errorf("no command specified")
+	}
+
+	t := &Tracer{
+		args:          command,
+		syscallStats:  make(map[uint32]uint64, 100),
+		fsActivity:    make(map[string]*FSActivityInfo, 100),
+		eventCh:       make(chan SyscallEvent, 2000),
+		done:          make(chan struct{}),
+		result:        make(chan TraceResult, 1),
+		signalCh:      opts.SignalCh,
+		pidSyscallMap: make(map[int]*SyscallState),
+		handlers:      make(map[int]SyscallHandler),
+		stdout:        os.Stdout,
+		stderr:        os.Stderr,
+	}
+
+	if opts.Stdout != nil {
+		t.stdout = opts.Stdout
+	}
+
+	if opts.Stderr != nil {
+		t.stderr = opts.Stderr
+	}
+
+	// Register architecture-specific syscall handlers
+	t.registerHandlers()
+
+	return t, nil
 }
 
+// Start begins the tracing process
 func (t *Tracer) Start(ctx context.Context) error {
-	if t.running {
-		return fmt.Errorf("tracer is already running")
-	}
-	t.running = true
-
-	cmd := exec.CommandContext(ctx, t.args[0], t.args[1:]...)
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	cmd.SysProcAttr = &unix.SysProcAttr{
-		Ptrace:  true,
-		Setpgid: true,
+	// Ensure result channel is initialized
+	if t.result == nil {
+		t.result = make(chan TraceResult, 1)
 	}
 
-	if err := cmd.Start(); err != nil {
-		t.running = false
-		return fmt.Errorf("failed to start command: %w", err)
-	}
-
-	t.cmd = cmd
-	mainPid := cmd.Process.Pid
-	clog.Infof("Started process with PID %d", mainPid)
-
-	// Wait for the first TRAP which indicates the process is stopped and ready to be traced
-	var ws unix.WaitStatus
-	pid, err := unix.Wait4(mainPid, &ws, 0, nil)
-	if err != nil {
-		t.running = false
-		return fmt.Errorf("failed to wait for initial trap: %w", err)
-	}
-
-	clog.Infof("Process initial status: pid=%d, status=%v (Exited=%v, Signaled=%v, Stopped=%v, StopSignal=%v, TrapCause=%v)",
-		pid, ws, ws.Exited(), ws.Signaled(), ws.Stopped(), ws.StopSignal(), ws.TrapCause())
-
-	if !ws.Stopped() {
-		t.running = false
-		return fmt.Errorf("process not stopped after start (pid=%d, status=%v)", pid, ws)
-	}
-
-	clog.Infof("Process stopped for tracing (pid=%d, signal=%v)", pid, ws.StopSignal())
-
-	// Configure tracing options
-	const ptOpts = unix.PTRACE_O_TRACECLONE |
-		unix.PTRACE_O_TRACEFORK |
-		unix.PTRACE_O_TRACEVFORK |
-		unix.PTRACE_O_TRACEEXEC |
-		unix.PTRACE_O_TRACESYSGOOD |
-		unix.PTRACE_O_TRACEEXIT |
-		unix.PTRACE_O_EXITKILL
-
-	if err := unix.PtraceSetOptions(mainPid, ptOpts); err != nil {
-		t.running = false
-		return fmt.Errorf("failed to set ptrace options: %w", err)
-	}
-
-	// Verify the process is still alive
-	if err := unix.Kill(mainPid, 0); err != nil {
-		t.running = false
-		return fmt.Errorf("process died after setting ptrace options: %w", err)
-	}
-
-	// Initialize the tracer's state map with the first process
-	cwd, _ := os.Getwd()
-	initialState := &syscallState{
-		pid:       mainPid,
-		cwd:       cwd,
-		fdTable:   make(map[int]FD),
-		childPids: make(map[int]bool),
-		startTime: time.Now(),
-		started:   true, // Mark as started immediately
-	}
-
-	t.statesMu.Lock()
-	t.states[mainPid] = initialState
-	t.statesMu.Unlock()
-
+	// Start event processing in a goroutine
 	go t.processEvents(ctx)
 
-	if err := unix.PtraceSyscall(mainPid, 0); err != nil {
-		t.running = false
-		return fmt.Errorf("failed to set initial syscall trace: %w", err)
-	}
-
-	// Start the tracing goroutine
-	go t.trace(ctx, cmd)
-	return nil
-}
-
-func (t *Tracer) Wait() <-chan struct{} {
-	return t.done
-}
-
-func (t *Tracer) Events() <-chan Event {
-	return t.events
-}
-
-func (t *Tracer) Stop() {
-	t.running = false
-}
-
-// syscallState tracks the state of a syscall being processed
-type syscallState struct {
-	pid          int          // Process ID
-	callNum      uint32       // System call number
-	retVal       uint64       // Return value from syscall
-	expectReturn bool         // Whether we're expecting a return from this syscall
-	gotCallNum   bool         // Whether we've gotten the syscall number
-	gotRetVal    bool         // Whether we've gotten the return value
-	started      bool         // Whether the process has started
-	exiting      bool         // Whether the process is exiting
-	pathParam    string       // Path parameter for syscalls that operate on paths
-	pathParamErr error        // Error when retrieving path parameter
-	dirfd        int          // Tracks directory file descriptor for *at syscalls
-	cwd          string       // Current working directory of the process
-	fdTable      map[int]FD   // Maps file descriptors to their paths
-	parentPid    int          // Parent process ID
-	childPids    map[int]bool // Child process IDs
-	startTime    time.Time    // Process start time
-}
-
-// FD represents a file descriptor and its associated information
-type FD struct {
-	Path     string // The path this file descriptor refers to
-	Type     string // Type of file descriptor (regular, socket, pipe, etc)
-	OpenTime time.Time
-}
-
-func (t *Tracer) trace(ctx context.Context, cmd *exec.Cmd) {
-	runtime.LockOSThread()
-	defer runtime.UnlockOSThread()
-
-	// Correctly handle cleanup but avoid sleep-based synchronization
-	defer func() {
-		clog.InfoContext(ctx, "Trace function exiting")
-		close(t.events)
+	// Start process tracing in a goroutine
+	go func() {
+		exitCode, err := t.trace(ctx)
+		select {
+		case t.result <- TraceResult{ExitCode: exitCode, Err: err}:
+		default:
+			// If channel is full, we'll just discard the result
+		}
 		close(t.done)
 	}()
 
-	// Get current working directory at the start
-	cwd, err := os.Getwd()
-	if err != nil {
-		cwd = "/" // Default to root if we can't get current directory
-		clog.ErrorContextf(ctx, "failed to get current working directory: %v", err)
+	// Start signal forwarding if we have a signal channel
+	if t.signalCh != nil {
+		go t.forwardSignals(ctx)
 	}
 
-	// Process group handling
-	mainPid := cmd.Process.Pid
-	pgid, err := unix.Getpgid(mainPid)
-	if err != nil {
-		clog.ErrorContextf(ctx, "failed to get process group ID: %v", err)
-		// Continue anyway, we'll just track individual processes
-	} else {
-		clog.InfoContextf(ctx, "tracking process group ID: %d", pgid)
-	}
-
-	// Initialize state tracking based on your implementation
-	mainExiting := false
-	_ = mainExiting
-	waitFor := mainPid
-	callSig := 0 // No signal initially
-
-	// Initialize process state similar to your implementation
-	t.statesMu.Lock()
-	if _, exists := t.states[mainPid]; !exists {
-		// In case it wasn't initialized yet
-		t.states[mainPid] = &syscallState{
-			pid:       mainPid,
-			cwd:       cwd,
-			fdTable:   make(map[int]FD),
-			childPids: make(map[int]bool),
-			startTime: time.Now(),
-			started:   true,
-		}
-	}
-	t.statesMu.Unlock()
-
-	for {
-		select {
-		case <-ctx.Done():
-			clog.InfoContext(ctx, "context done, exiting tracer")
-			return
-		default:
-			// Continue with syscall tracing, matching your implementation style
-			clog.DebugContextf(ctx, "trace syscall (pid=%v sig=%v)", waitFor, callSig)
-			err := unix.PtraceSyscall(waitFor, callSig)
-			if err != nil {
-				if strings.Contains(err.Error(), "no such process") {
-					// Process might have terminated very quickly
-					clog.Debugf("PtraceSyscall: Process %d no longer exists", waitFor)
-
-					// If this was the main process and we're just starting
-					if waitFor == mainPid {
-						clog.Warnf("Main process %d terminated very quickly after initial stop", mainPid)
-
-						// Check if process actually exists via /proc
-						_, procErr := os.Stat(fmt.Sprintf("/proc/%d", mainPid))
-						if procErr != nil && os.IsNotExist(procErr) {
-							clog.Infof("Confirmed main process %d no longer exists", mainPid)
-							// Report exit
-							select {
-							case t.events <- Event{
-								Type:        EventExit,
-								Pid:         mainPid,
-								SyscallName: "exit",
-								Path:        fmt.Sprintf("process %d exited very quickly", mainPid),
-							}:
-							default:
-								clog.Warnf("Failed to send exit event, channel full")
-							}
-
-							select {
-							case t.done <- struct{}{}:
-							default:
-							}
-							return
-						}
-					}
-
-					// Try waiting for any process instead
-					waitFor = -1
-					continue
-				} else {
-					clog.ErrorContextf(ctx, "failed to syscall ptrace syscall: %v", err)
-				}
-			}
-			callSig = 0 // Reset signal after use
-
-			// Wait for syscall or other ptrace events
-			var ws unix.WaitStatus
-			wpid, err := unix.Wait4(waitFor, &ws, unix.WALL, nil)
-
-			// Additional debug for first loop iteration
-			if waitFor == mainPid {
-				clog.Debugf("First wait4 after stop - result: pid=%d, error=%v, status=%v",
-					wpid, err, ws)
-			}
-
-			if err != nil {
-				if err == unix.ECHILD {
-					clog.InfoContext(ctx, "no more child processes")
-					return
-				}
-				clog.Warnf("wait4 error: %v (errno=%d)", err, err.(syscall.Errno))
-
-				// If this was the first wait for main PID, handle specially
-				if waitFor == mainPid {
-					clog.Warnf("Error waiting for main PID on first trace iteration")
-					// Check if process exists
-					_, procErr := os.Stat(fmt.Sprintf("/proc/%d", mainPid))
-					if procErr != nil && os.IsNotExist(procErr) {
-						clog.Infof("Main process %d no longer exists after first start", mainPid)
-						// Report exit and terminate
-						t.events <- Event{
-							Type:        EventExit,
-							Pid:         mainPid,
-							SyscallName: "exit",
-							Path:        "main process exited immediately",
-						}
-						select {
-						case t.done <- struct{}{}:
-						default:
-						}
-						return
-					}
-				}
-				waitFor = -1
-				continue
-			}
-
-			// Debug output for event type
-			eventType := "unknown"
-			if ws.Exited() {
-				eventType = "exited"
-			} else if ws.Signaled() {
-				eventType = "signaled"
-			} else if ws.Stopped() {
-				eventType = "stopped"
-			}
-			clog.DebugContextf(ctx, "wait4 => pid=%d event=%s status=%d", wpid, eventType, ws)
-
-			// Handle the event based on type
-			if ws.Exited() {
-				// Process exited normally
-				exitStatus := ws.ExitStatus()
-				clog.InfoContextf(ctx, "process %d exited with status: %d", wpid, exitStatus)
-
-				// Clean up from registry and state tracking
-				processRegistry.Delete(wpid)
-
-				// Clean up our states map
-				t.statesMu.Lock()
-				// Update parent to remove this child if known
-				if state, exists := t.states[wpid]; exists && state.parentPid != 0 {
-					if parentState, parentExists := t.states[state.parentPid]; parentExists {
-						delete(parentState.childPids, wpid)
-					}
-				}
-
-				// Remove the process from our tracked states
-				delete(t.states, wpid)
-
-				// Check if this was the main process
-				if wpid == mainPid {
-					mainExiting = true
-					clog.InfoContext(ctx, "main process exited")
-				}
-
-				// Exit if no more processes to track
-				hasProcesses := len(t.states) > 0
-				t.statesMu.Unlock()
-
-				if !hasProcesses {
-					clog.InfoContext(ctx, "all processes exited, stopping tracer")
-					return
-				}
-
-				waitFor = -1 // Wait for any process
-				continue
-			}
-
-			if ws.Signaled() {
-				// Process terminated by signal
-				signum := ws.Signal()
-				clog.InfoContextf(ctx, "process %d terminated by signal: %v", wpid, signum)
-
-				// Clean up state
-				processRegistry.Delete(wpid)
-
-				t.statesMu.Lock()
-				delete(t.states, wpid)
-
-				if wpid == mainPid {
-					mainExiting = true
-				}
-
-				hasProcesses := len(t.states) > 0
-				t.statesMu.Unlock()
-
-				if !hasProcesses {
-					clog.InfoContext(ctx, "all processes exited, stopping tracer")
-					return
-				}
-
-				waitFor = -1
-				continue
-			}
-
-			if ws.Stopped() {
-				sig := ws.StopSignal()
-				trapCause := ws.TrapCause()
-
-				// Handle different stop causes
-				if (sig == unix.SIGTRAP) && ((trapCause&0xff) == unix.PTRACE_EVENT_CLONE ||
-					(trapCause&0xff) == unix.PTRACE_EVENT_FORK ||
-					(trapCause&0xff) == unix.PTRACE_EVENT_VFORK) {
-
-					// Handle new process creation
-					newPid, err := unix.PtraceGetEventMsg(wpid)
-					if err != nil {
-						clog.ErrorContextf(ctx, "failed to get event message for clone/fork: %v", err)
-					} else {
-						newPidInt := int(newPid)
-						clog.InfoContextf(ctx, "new process created: parent=%d child=%d", wpid, newPidInt)
-
-						// Create state for the new process
-						t.statesMu.Lock()
-						if parentState, exists := t.states[wpid]; exists {
-							// Copy parent's state for child
-							childState := &syscallState{
-								pid:       newPidInt,
-								parentPid: wpid,
-								cwd:       parentState.cwd,
-								fdTable:   make(map[int]FD),
-								childPids: make(map[int]bool),
-								startTime: time.Now(),
-							}
-
-							// Copy FDs from parent
-							for fd, info := range parentState.fdTable {
-								childState.fdTable[fd] = info
-							}
-
-							// Add to tracking
-							t.states[newPidInt] = childState
-
-							// Add to parent's children
-							parentState.childPids[newPidInt] = true
-						} else {
-							// Parent not found, create minimal state
-							t.states[newPidInt] = &syscallState{
-								pid:       newPidInt,
-								parentPid: wpid,
-								fdTable:   make(map[int]FD),
-								childPids: make(map[int]bool),
-								startTime: time.Now(),
-							}
-						}
-						t.statesMu.Unlock()
-					}
-
-					// Continue process
-					if err := unix.PtraceSyscall(wpid, 0); err != nil {
-						clog.ErrorContextf(ctx, "failed to continue process after clone/fork: %v", err)
-					}
-
-					waitFor = -1 // Wait for any process
-					continue
-				}
-
-				// Handle exec events
-				if (sig == unix.SIGTRAP) && ((trapCause & 0xff) == unix.PTRACE_EVENT_EXEC) {
-					clog.InfoContextf(ctx, "process %d executed a new program", wpid)
-
-					// Update state for exec'd process
-					t.statesMu.Lock()
-					if state, exists := t.states[wpid]; exists {
-						// Reset file descriptors except stdin/stdout/stderr
-						newFdTable := make(map[int]FD)
-						for fd := 0; fd <= 2; fd++ {
-							if oldFd, hasOld := state.fdTable[fd]; hasOld {
-								newFdTable[fd] = oldFd
-							}
-						}
-						state.fdTable = newFdTable
-
-						// Try to update working directory
-						if procCwd, err := os.Readlink(fmt.Sprintf("/proc/%d/cwd", wpid)); err == nil {
-							state.cwd = procCwd
-						}
-					}
-					t.statesMu.Unlock()
-
-					// Continue process
-					if err := unix.PtraceSyscall(wpid, 0); err != nil {
-						clog.ErrorContextf(ctx, "failed to continue process after exec: %v", err)
-					}
-
-					waitFor = -1
-					continue
-				}
-
-				// Handle exit notifications
-				if (sig == unix.SIGTRAP) && ((trapCause & 0xff) == unix.PTRACE_EVENT_EXIT) {
-					t.statesMu.Lock()
-					if state, exists := t.states[wpid]; exists {
-						state.exiting = true
-					}
-					t.statesMu.Unlock()
-
-					clog.InfoContextf(ctx, "process %d is about to exit", wpid)
-
-					if wpid == mainPid {
-						mainExiting = true
-						clog.InfoContext(ctx, "main process is about to exit")
-					}
-
-					// Continue the process to let it exit
-					if err := unix.PtraceSyscall(wpid, 0); err != nil {
-						clog.ErrorContextf(ctx, "failed to continue exiting process: %v", err)
-					}
-
-					waitFor = -1
-					continue
-				}
-
-				// Handle syscall stop
-				if sig == unix.SIGTRAP|0x80 {
-					// Process syscall
-					handleSyscall(t, wpid)
-
-					// Continue with syscall tracing
-					if err := unix.PtraceSyscall(wpid, 0); err != nil {
-						if strings.Contains(err.Error(), "no such process") {
-							// Process might have terminated between wait4 and here
-							clog.DebugContextf(ctx, "process no longer exists pid=%v", wpid)
-						} else {
-							clog.ErrorContextf(ctx, "failed to continue process after syscall: %v", err)
-						}
-					}
-
-					waitFor = -1
-					continue
-				}
-
-				// Forward other stop signals to the process
-				callSig = int(sig)
-				if err := unix.PtraceSyscall(wpid, callSig); err != nil {
-					clog.ErrorContextf(ctx, "failed to continue process with signal: %v", err)
-				}
-
-				waitFor = -1
-				continue
-			}
-		}
-	}
+	return nil
 }
 
-// Add an event processor function that handles events and completion
-func (t *Tracer) processEvents(ctx context.Context) {
-	defer func() {
-		clog.InfoContext(ctx, "Event processor exiting")
-	}()
-
+// forwardSignals forwards received signals to the traced process
+func (t *Tracer) forwardSignals(ctx context.Context) {
 	for {
 		select {
 		case <-ctx.Done():
-			clog.InfoContext(ctx, "Context cancelled, stopping event processor")
 			return
 
-		case event, ok := <-t.events:
+		case sig, ok := <-t.signalCh:
 			if !ok {
-				clog.InfoContext(ctx, "Event channel closed")
 				return
 			}
 
-			// Process the event
-			clog.DebugContextf(ctx, "Processing event: %s (pid=%d path=%s)",
-				event.SyscallName, event.Pid, event.Path)
+			if sig == syscall.SIGCHLD {
+				continue // Ignore SIGCHLD
+			}
 
-			// Handle special event types
-			if event.Type == EventExit {
-				clog.InfoContextf(ctx, "Process exit event: %d", event.Pid)
-
-				// Check if this is the main process
-				if event.Pid == t.cmd.Process.Pid {
-					clog.InfoContext(ctx, "Main process exited")
-					return
+			// Convert to syscall.Signal if possible
+			if ss, ok := sig.(syscall.Signal); ok {
+				// Use syscall.Kill directly with the process group
+				// because tracee's status is already captured by ptrace
+				if err := syscall.Kill(t.cmd.Process.Pid, ss); err != nil {
+					fmt.Fprintf(t.stderr, "Failed to forward signal %v: %v\n", ss, err)
 				}
 			}
 		}
 	}
 }
 
-func getStringParam(pid int, addr uint64) (string, error) {
-	// Start with a smaller buffer for efficiency
-	buf := make([]byte, 256)
-	_, err := unix.PtracePeekData(pid, uintptr(addr), buf)
+// Wait waits for the tracing to complete and returns a report with statistics
+func (t *Tracer) Wait() *TraceReport {
+	// Wait for completion
+	<-t.done
+
+	// Get the result with exit code, safely handling an empty channel
+	var result TraceResult
+	select {
+	case r, ok := <-t.result:
+		if ok {
+			result = r
+		}
+	default:
+		// If result channel is empty, assume successful exit with no error
+		result = TraceResult{ExitCode: 0, Err: nil}
+	}
+
+	// Create a deep copy of the statistics maps to prevent concurrent access
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	// Calculate total syscall count
+	var totalSyscalls uint64
+	for _, count := range t.syscallStats {
+		totalSyscalls += count
+	}
+
+	// Copy syscall statistics to prevent concurrent modification
+	syscallStats := make(map[uint32]uint64, len(t.syscallStats))
+	for num, count := range t.syscallStats {
+		syscallStats[num] = count
+	}
+
+	// Use a radix tree for efficient path hierarchy management
+	tree := radix.New()
+	for path, info := range t.fsActivity {
+		tree.Insert(path, info)
+	}
+
+	// Copy and filter file activity information using the radix tree
+	fsActivity := make(map[string]*FSActivityInfo, len(t.fsActivity))
+
+	// Mark paths that are parents of other paths
+	isParent := make(map[string]bool)
+
+	// Walk through the tree to identify parent paths
+	tree.Walk(func(path string, value interface{}) bool {
+		// For each path, check if it's a prefix of other paths
+		tree.WalkPrefix(path+"/", func(childPath string, childValue interface{}) bool {
+			if childPath != path {
+				isParent[path] = true
+			}
+			return false // Continue walking
+		})
+		return false // Continue walking
+	})
+
+	// Only include leaf paths (not parents) and create deep copies
+	for path, info := range t.fsActivity {
+		if !isParent[path] {
+			// Create deep copy of the FSActivityInfo
+			newInfo := &FSActivityInfo{
+				OpsAll:       info.OpsAll,
+				OpsCheckFile: info.OpsCheckFile,
+				Pids:         make(map[int]struct{}, len(info.Pids)),
+				Syscalls:     make(map[int]struct{}, len(info.Syscalls)),
+			}
+
+			// Copy process IDs that accessed this path
+			for pid := range info.Pids {
+				newInfo.Pids[pid] = struct{}{}
+			}
+
+			// Copy syscalls that accessed this path
+			for syscallNum := range info.Syscalls {
+				newInfo.Syscalls[syscallNum] = struct{}{}
+			}
+
+			fsActivity[path] = newInfo
+		}
+	}
+
+	// Create and return the report
+	report := &TraceReport{
+		TotalSyscalls: totalSyscalls,
+		ExitCode:      result.ExitCode,
+		SyscallStats:  syscallStats,
+		FSActivity:    fsActivity,
+	}
+
+	return report
+}
+
+// shouldBeIncluded checks if a path should be included in the final report
+// It returns false if the path is a subpath of another path in the map
+func shouldBeIncluded(path string, allPaths map[string]*FSActivityInfo) bool {
+	// Always include the path itself
+	if path == "" || path == "/" {
+		return true
+	}
+
+	// Check if this path is a parent of any other path
+	isParentPath := false
+	for otherPath := range allPaths {
+		if otherPath != path && strings.HasPrefix(otherPath, path+"/") {
+			isParentPath = true
+			break
+		}
+	}
+
+	// Include if this is a leaf path (not a parent of any other path)
+	return !isParentPath
+}
+
+// TraceReport contains the results of the tracing
+type TraceReport struct {
+	TotalSyscalls uint64                     // Total number of syscalls traced
+	ExitCode      int                        // Exit code of the traced process
+	SyscallStats  map[uint32]uint64          // Statistics for each syscall
+	FSActivity    map[string]*FSActivityInfo // File system activity
+}
+
+// trace starts the ptrace process
+func (t *Tracer) trace(ctx context.Context) (int, error) {
+	// Ensure result channel is initialized
+	if t.result == nil {
+		t.result = make(chan TraceResult, 1)
+	}
+
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
+	// Use a potentially-cancellable command
+	cmd := exec.CommandContext(ctx, t.args[0], t.args[1:]...)
+	cmd.Stdout = t.stdout
+	cmd.Stderr = t.stderr
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		Ptrace: true,
+	}
+
+	if err := cmd.Start(); err != nil {
+		// Avoid blocking by using select with default
+		select {
+		case t.result <- TraceResult{ExitCode: 1, Err: fmt.Errorf("failed to start command: %w", err)}:
+		default:
+		}
+		fmt.Fprintf(t.stderr, "Failed to start command: %v\n", err)
+		return 1, fmt.Errorf("failed to start command: %w", err)
+	}
+
+	t.cmd = cmd
+
+	// Check if context is already canceled
+	select {
+	case <-ctx.Done():
+		// Avoid blocking by using select with default
+		select {
+		case t.result <- TraceResult{ExitCode: 1, Err: ctx.Err()}:
+		default:
+		}
+		fmt.Fprintf(t.stderr, "Context canceled before tracing could start\n")
+		return 1, fmt.Errorf("context canceled before tracing could start")
+	default:
+	}
+
+	// Wait for first stop - process stops after exec due to ptrace
+	var ws syscall.WaitStatus
+	_, err := syscall.Wait4(cmd.Process.Pid, &ws, 0, nil)
 	if err != nil {
-		return "", fmt.Errorf("error reading string parameter: %w", err)
-	}
-
-	// Find null terminator
-	end := bytes.IndexByte(buf, 0)
-	if end == -1 {
-		// If not found in the small buffer, try a larger one
-		buf = make([]byte, 4096)
-		_, err := unix.PtracePeekData(pid, uintptr(addr), buf)
-		if err != nil {
-			return "", fmt.Errorf("error reading string parameter with larger buffer: %w", err)
+		// Avoid blocking by using select with default
+		select {
+		case t.result <- TraceResult{ExitCode: 1, Err: fmt.Errorf("wait4 failed: %w", err)}:
+		default:
 		}
-
-		end = bytes.IndexByte(buf, 0)
-		if end == -1 {
-			// If still not found, this might be an invalid string pointer
-			return "", fmt.Errorf("unable to find null terminator in string at 0x%x", addr)
-		}
+		fmt.Fprintf(t.stderr, "Wait4 failed: %v\n", err)
+		return 1, fmt.Errorf("wait4 failed: %w", err)
 	}
 
-	return string(buf[:end]), nil
-}
-
-// fdName returns a human-readable name for common file descriptors
-func fdName(fd int) string {
-	switch fd {
-	case 0:
-		return "STDIN"
-	case 1:
-		return "STDOUT"
-	case 2:
-		return "STDERR"
-	case AT_FDCWD:
-		return "AT_FDCWD"
-	}
-	return ""
-}
-
-// resolvePath resolves a path based on the process state
-// It handles relative paths, AT_FDCWD, and absolute paths
-func (t *Tracer) resolvePath(pid int, path string, dirfd int) string {
-	// If it's an absolute path, just return it regardless of state
-	if filepath.IsAbs(path) {
-		return filepath.Clean(path)
-	}
-
-	// First check if the process exists before trying to access it
-	_, err := os.Stat(fmt.Sprintf("/proc/%d", pid))
+	// Get process group ID for signal handling
+	t.pgid, err = syscall.Getpgid(cmd.Process.Pid)
 	if err != nil {
-		if os.IsNotExist(err) {
-			// Process is already gone, just clean the path and return
-			clog.Debugf("Process %d no longer exists when resolving path %s, using best effort", pid, path)
-			return filepath.Clean(path)
+		// Avoid blocking by using select with default
+		select {
+		case t.result <- TraceResult{ExitCode: 1, Err: fmt.Errorf("failed to get process group: %w", err)}:
+		default:
 		}
+		fmt.Fprintf(t.stderr, "Failed to get process group: %v\n", err)
+		return 1, fmt.Errorf("failed to get process group: %w", err)
 	}
 
-	// Get state safely
-	t.statesMu.RLock()
-	state, ok := t.states[pid]
+	// Set comprehensive ptrace options
+	err = syscall.PtraceSetOptions(cmd.Process.Pid, ptOptions)
+	if err != nil {
+		// Avoid blocking by using select with default
+		select {
+		case t.result <- TraceResult{ExitCode: 1, Err: fmt.Errorf("failed to set ptrace options: %w", err)}:
+		default:
+		}
+		fmt.Fprintf(t.stderr, "Failed to set ptrace options: %v\n", err)
+		return 1, fmt.Errorf("failed to set ptrace options: %w", err)
+	}
 
-	// Make local copies of needed values under lock
-	var cwd, fdPath string
-	var parentPid int
+	// Initialize state for the main process
+	t.pidSyscallMap[cmd.Process.Pid] = &SyscallState{
+		pid: cmd.Process.Pid,
+	}
 
-	if ok && state != nil {
-		cwd = state.cwd
-		parentPid = state.parentPid
+	// Main tracing loop
+	exitCode, err := t.traceLoop(ctx)
+	return exitCode, err
+}
 
-		// If path is empty and dirfd is valid, try to get fd path
-		if path == "" && dirfd > 0 && state.fdTable != nil {
-			if fd, fdOk := state.fdTable[dirfd]; fdOk {
-				fdPath = fd.Path
+// traceLoop is the main loop for tracking syscalls
+func (t *Tracer) traceLoop(ctx context.Context) (int, error) {
+	var callPid int
+	callPid = t.cmd.Process.Pid
+
+	callSig := 0
+	waitFor := -1
+	doSyscall := true
+
+	// Create a cleanup function to ensure we detach from any remaining processes
+	defer func() {
+		// Clean up any remaining traced processes
+		for pid := range t.pidSyscallMap {
+			// Try to detach from the process
+			_ = syscall.PtraceDetach(pid)
+			delete(t.pidSyscallMap, pid)
+		}
+	}()
+
+	for {
+		// Check if context is done
+		select {
+		case <-ctx.Done():
+			// Clean up and exit when context is cancelled
+			for pid := range t.pidSyscallMap {
+				_ = syscall.PtraceDetach(pid)
 			}
-		} else if dirfd != AT_FDCWD && state.fdTable != nil {
-			// Try to get file descriptor path for non-AT_FDCWD
-			if fd, fdOk := state.fdTable[dirfd]; fdOk {
-				fdPath = fd.Path
+			return 0, ctx.Err()
+		default:
+		}
+
+		// Continue execution with syscall tracing
+		if doSyscall {
+			err := syscall.PtraceSyscall(callPid, callSig)
+			if err != nil {
+				// Handle process no longer existing
+				if errno, ok := err.(syscall.Errno); ok && errno == syscall.ESRCH {
+					delete(t.pidSyscallMap, callPid)
+					doSyscall = false
+					continue
+				}
+				// For other errors, try to clean up but continue with other processes
+				doSyscall = false
+				continue
 			}
 		}
-	}
-	t.statesMu.RUnlock()
 
-	// If we don't have state for this pid or cwd is empty, try to determine from /proc
-	if !ok || cwd == "" {
-		// Double-check process exists before accessing /proc
-		_, err := os.Stat(fmt.Sprintf("/proc/%d", pid))
+		// Wait for syscall or other event with a check to ensure we're not blocking indefinitely
+		var ws syscall.WaitStatus
+		wpid, err := syscall.Wait4(waitFor, &ws, syscall.WALL, nil)
 		if err != nil {
-			if os.IsNotExist(err) {
-				// Process is gone, just clean the path and return
-				clog.Debugf("Process %d no longer exists when trying to get cwd, using best effort", pid)
-				return filepath.Clean(path)
-			}
-		}
-
-		procCwd, err := os.Readlink(fmt.Sprintf("/proc/%d/cwd", pid))
-		if err == nil {
-			// Cache in our state for future use
-			if ok {
-				t.statesMu.Lock()
-				if st, exists := t.states[pid]; exists && st != nil {
-					st.cwd = procCwd
+			if errno, ok := err.(syscall.Errno); ok && errno == syscall.ECHILD {
+				// No more children - make sure we don't have any zombie pids in our map
+				if len(t.pidSyscallMap) == 0 {
+					return 0, nil
 				}
-				t.statesMu.Unlock()
+
+				// Clean up any processes that might not have been properly waited for
+				for pid := range t.pidSyscallMap {
+					// Try to detach from any processes still in the map
+					_ = syscall.PtraceDetach(pid)
+					delete(t.pidSyscallMap, pid)
+				}
+
+				if len(t.pidSyscallMap) == 0 {
+					return 0, nil
+				}
+
+				doSyscall = false
+				continue
 			}
 
-			// For relative paths, join with cwd
-			if !filepath.IsAbs(path) && path != "" {
-				return filepath.Clean(filepath.Join(procCwd, path))
+			// Clean up before returning error
+			for pid := range t.pidSyscallMap {
+				_ = syscall.PtraceDetach(pid)
 			}
-			cwd = procCwd
+			return 1, fmt.Errorf("wait4 failed: %w", err)
 		}
 
-		// If no cwd found and path is relative, use current directory as fallback
-		if cwd == "" && !filepath.IsAbs(path) && path != "" {
-			wd, err := os.Getwd()
-			if err == nil {
-				return filepath.Clean(filepath.Join(wd, path))
-			}
-			// Ultimate fallback
-			return filepath.Clean(path)
-		}
-	}
+		// Reset signal
+		callSig = 0
 
-	// Handle empty paths specially, some syscalls use empty path to operate on the dirfd itself
-	if path == "" && dirfd > 0 {
-		if fdPath != "" {
-			return fdPath
-		}
+		// Handle process termination
+		if ws.Exited() || ws.Signaled() {
+			delete(t.pidSyscallMap, wpid)
 
-		// Try to resolve from /proc if not in our fd table
-		dirPath, err := os.Readlink(fmt.Sprintf("/proc/%d/fd/%d", pid, dirfd))
-		if err == nil {
-			// Cache for future use
-			t.statesMu.Lock()
-			if st, exists := t.states[pid]; exists && st != nil && st.fdTable != nil {
-				st.fdTable[dirfd] = FD{
-					Path:     dirPath,
-					Type:     "regular",
-					OpenTime: time.Now(),
+			// If main process terminated, we're done when all children are finished
+			if wpid == t.cmd.Process.Pid {
+				if len(t.pidSyscallMap) == 0 {
+					return ws.ExitStatus(), nil
 				}
 			}
-			t.statesMu.Unlock()
-			return dirPath
+
+			doSyscall = false
+			continue
 		}
 
-		// Fall back to a placeholder
-		return fmt.Sprintf("<fd:%d>", dirfd)
-	}
+		// Handle syscall-stop or other stops
+		if ws.Stopped() {
+			stopSig := int(ws.StopSignal())
 
-	// Special case for AT_FDCWD (-100), use the process's cwd
-	if dirfd == AT_FDCWD || dirfd == 0 {
-		// Use most up-to-date cwd
-		if cwd != "" {
-			return filepath.Clean(filepath.Join(cwd, path))
-		}
-
-		// Check if process still exists
-		_, procErr := os.Stat(fmt.Sprintf("/proc/%d", pid))
-		if procErr != nil && os.IsNotExist(procErr) {
-			// Process is gone, clean the path and return best effort
-			clog.Debugf("Process %d no longer exists when getting cwd, using best effort", pid)
-			return filepath.Clean(path)
-		}
-
-		// Try to get cwd from /proc as a fallback
-		procCwd, err := os.Readlink(fmt.Sprintf("/proc/%d/cwd", pid))
-		if err == nil {
-			// Update our cached cwd
-			t.statesMu.Lock()
-			if st, exists := t.states[pid]; exists && st != nil {
-				st.cwd = procCwd
-			}
-			t.statesMu.Unlock()
-			return filepath.Clean(filepath.Join(procCwd, path))
-		}
-
-		// Ultimate fallback - current process working directory
-		wd, err := os.Getwd()
-		if err == nil {
-			return filepath.Clean(filepath.Join(wd, path))
-		}
-
-		// If everything fails, just clean the path
-		return filepath.Clean(path)
-	}
-
-	// For non-AT_FDCWD cases, check if we have fdPath
-	if fdPath != "" {
-		return filepath.Clean(filepath.Join(fdPath, path))
-	}
-
-	// First check if the process still exists
-	_, procErr := os.Stat(fmt.Sprintf("/proc/%d", pid))
-	if procErr != nil {
-		if os.IsNotExist(procErr) {
-			// Process is gone, just clean the path and return
-			clog.Debugf("Process %d no longer exists when trying to get fd=%d, using best effort", pid, dirfd)
-			return filepath.Clean(path)
-		}
-	}
-
-	// If we don't know the file descriptor, try to read it from /proc
-	dirPath, err := os.Readlink(fmt.Sprintf("/proc/%d/fd/%d", pid, dirfd))
-	if err == nil {
-		// Cache this file descriptor for future use
-		t.statesMu.Lock()
-		if st, exists := t.states[pid]; exists && st != nil && st.fdTable != nil {
-			st.fdTable[dirfd] = FD{
-				Path:     dirPath,
-				Type:     "unknown",
-				OpenTime: time.Now(),
-			}
-		}
-		t.statesMu.Unlock()
-		return filepath.Clean(filepath.Join(dirPath, path))
-	}
-
-	// If we still can't resolve it but have a parent process,
-	// check if the parent has this fd (might be inherited)
-	if parentPid > 0 {
-		var parentFdPath string
-		t.statesMu.RLock()
-		if parentState, ok := t.states[parentPid]; ok && parentState != nil && parentState.fdTable != nil {
-			if parentFd, ok := parentState.fdTable[dirfd]; ok {
-				parentFdPath = parentFd.Path
-			}
-		}
-		t.statesMu.RUnlock()
-
-		if parentFdPath != "" {
-			// Copy to this process's fd table
-			t.statesMu.Lock()
-			if st, exists := t.states[pid]; exists && st != nil && st.fdTable != nil {
-				st.fdTable[dirfd] = FD{
-					Path:     parentFdPath,
-					Type:     "inherited",
-					OpenTime: time.Now(),
+			// Check if this is a syscall stop
+			if stopSig == int(syscall.SIGTRAP|0x80) {
+				var cstate *SyscallState
+				if state, ok := t.pidSyscallMap[wpid]; ok {
+					cstate = state
+				} else {
+					// New process
+					cstate = &SyscallState{pid: wpid}
+					t.pidSyscallMap[wpid] = cstate
 				}
+
+				// Handle syscall entry or exit
+				if !cstate.expectReturn {
+					// Syscall entry
+					var regs syscall.PtraceRegs
+					if err := syscall.PtraceGetRegs(wpid, &regs); err == nil {
+						callNum := getSyscallNumber(regs)
+						cstate.callNum = callNum
+						cstate.expectReturn = true
+						cstate.gotCallNum = true
+
+						// Process syscall entry if we have a handler
+						if handler, ok := t.handlers[int(cstate.callNum)]; ok {
+							handler.OnCall(wpid, regs, cstate)
+						}
+					} else if errno, ok := err.(syscall.Errno); ok && errno == syscall.ESRCH {
+						// Process disappeared, clean it up
+						delete(t.pidSyscallMap, wpid)
+					}
+				} else {
+					// Syscall exit
+					var regs syscall.PtraceRegs
+					if err := syscall.PtraceGetRegs(wpid, &regs); err == nil {
+						retVal := getReturnValue(regs)
+						cstate.retVal = retVal
+						cstate.expectReturn = false
+						cstate.gotRetVal = true
+
+						// Process syscall exit if we have a handler
+						if handler, ok := t.handlers[int(cstate.callNum)]; ok {
+							handler.OnReturn(wpid, regs, cstate)
+						}
+
+						// Send event
+						if cstate.gotCallNum && cstate.gotRetVal {
+							event := SyscallEvent{
+								returned:  true,
+								pid:       wpid,
+								callNum:   uint32(cstate.callNum),
+								retVal:    cstate.retVal,
+								pathParam: cstate.pathParam,
+							}
+
+							select {
+							case t.eventCh <- event:
+							case <-ctx.Done():
+								// Clean up and exit when context is cancelled
+								for pid := range t.pidSyscallMap {
+									_ = syscall.PtraceDetach(pid)
+								}
+								return 0, ctx.Err()
+							default:
+								// Channel buffer full, drop event
+							}
+
+							// Reset state
+							cstate.gotCallNum = false
+							cstate.gotRetVal = false
+							cstate.pathParam = ""
+						}
+					} else if errno, ok := err.(syscall.Errno); ok && errno == syscall.ESRCH {
+						// Process disappeared, clean it up
+						delete(t.pidSyscallMap, wpid)
+					}
+				}
+			} else if stopSig == int(syscall.SIGTRAP) {
+				// Handle trace events (clone, fork, exec)
+				cause := ws.TrapCause()
+
+				switch cause {
+				case syscall.PTRACE_EVENT_CLONE,
+					syscall.PTRACE_EVENT_FORK,
+					syscall.PTRACE_EVENT_VFORK:
+					// New process created
+					newPid, err := syscall.PtraceGetEventMsg(wpid)
+					if err == nil {
+						// Create new process state with parent relationship
+						t.pidSyscallMap[int(newPid)] = &SyscallState{
+							pid:     int(newPid),
+							started: true,
+							parent:  wpid, // Record parent process
+						}
+
+						// Update parent's children list
+						if parentState, ok := t.pidSyscallMap[wpid]; ok {
+							parentState.children = append(parentState.children, int(newPid))
+						}
+
+						// Try to read the command line for the new process
+						// This might not be available immediately after fork/clone
+						if cmdline, err := os.ReadFile(fmt.Sprintf("/proc/%d/cmdline", int(newPid))); err == nil {
+							t.pidSyscallMap[int(newPid)].cmdline = string(cmdline)
+						}
+					}
+
+				case syscall.PTRACE_EVENT_EXEC:
+					// Process executed new program
+					_, err := syscall.PtraceGetEventMsg(wpid)
+					if err == nil {
+						// Update command line after exec
+						if cmdline, err := os.ReadFile(fmt.Sprintf("/proc/%d/cmdline", wpid)); err == nil {
+							if state, ok := t.pidSyscallMap[wpid]; ok {
+								state.cmdline = string(cmdline)
+							}
+						}
+
+						// Record the exec event
+						if state, ok := t.pidSyscallMap[wpid]; ok && state.pathParam != "" {
+							// Generate an exec event if there's a path parameter
+							event := SyscallEvent{
+								returned:  false, // Exec doesn't return on success
+								pid:       wpid,
+								callNum:   uint32(state.callNum),
+								pathParam: state.pathParam,
+							}
+
+							select {
+							case t.eventCh <- event:
+							case <-ctx.Done():
+								// Clean up and exit when context is cancelled
+								for pid := range t.pidSyscallMap {
+									_ = syscall.PtraceDetach(pid)
+								}
+								return 0, ctx.Err()
+							default:
+								// Channel full, drop event
+							}
+						}
+					}
+
+				case syscall.PTRACE_EVENT_EXIT:
+					// Process is about to exit
+					if state, ok := t.pidSyscallMap[wpid]; ok {
+						state.exiting = true
+
+						// Special handling for main process exit
+						if wpid == t.cmd.Process.Pid {
+							// Don't delete the state yet, but mark it for special handling
+							fmt.Fprintf(t.stderr, "Main process %d is exiting\n", wpid)
+
+							// If no children, we can detach and exit now
+							if len(state.children) == 0 {
+								// Return the actual exit status of the main process if available
+								if ws.Exited() {
+									return ws.ExitStatus(), nil
+								}
+								return 0, nil
+							}
+						}
+					}
+				}
+			} else {
+				// Forward signal to the process
+				callSig = stopSig
 			}
-			t.statesMu.Unlock()
-			return filepath.Clean(filepath.Join(parentFdPath, path))
+		}
+
+		// Continue with next process
+		doSyscall = true
+		callPid = wpid
+	}
+}
+
+// processEvents handles events from the trace process
+func (t *Tracer) processEvents(ctx context.Context) {
+	for {
+		select {
+		case <-ctx.Done():
+			// Context was canceled, stop processing
+			return
+
+		case event, ok := <-t.eventCh:
+			if !ok {
+				// Channel closed, stop processing
+				return
+			}
+			t.handleSyscallEvent(event)
+
+		case <-t.done:
+			// Tracing is complete
+			return
 		}
 	}
+}
 
-	// If all else fails, just join with the cwd (best effort)
-	clog.Infof("unable to resolve fd %d for pid %d, falling back to cwd", dirfd, pid)
-	if cwd != "" {
-		return filepath.Clean(filepath.Join(cwd, path))
+// handleSyscallEvent processes a single syscall event
+func (t *Tracer) handleSyscallEvent(event SyscallEvent) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	// Always record syscall statistics
+	t.syscallStats[event.callNum]++
+
+	// Skip events without path parameters
+	if event.pathParam == "" {
+		return
 	}
-	return filepath.Clean(path)
+
+	// Apply path filtering early - use global function instead of method
+	if shouldSkipPath(event.pathParam) {
+		return
+	}
+
+	// Skip events that don't have a handler
+	handler, ok := t.handlers[int(event.callNum)]
+	if !ok {
+		return // No handler for this syscall
+	}
+
+	// Process according to syscall type
+	switch handler.SyscallType() {
+	case CheckFileType:
+		// For check operations, always record
+		t.recordFileActivity(event, handler)
+
+	case OpenFileType:
+		// For open operations, only record successful ones
+		if !event.returned || handler.OKReturnStatus(event.retVal) {
+			t.recordFileActivity(event, handler)
+		}
+
+	case ExecType:
+		// For exec operations, always record
+		t.recordFileActivity(event, handler)
+	}
+}
+
+// recordFileActivity records file access activity
+func (t *Tracer) recordFileActivity(event SyscallEvent, handler SyscallHandler) {
+	if fsa, ok := t.fsActivity[event.pathParam]; ok {
+		// Update existing record
+		fsa.OpsAll++
+		if handler.SyscallType() == CheckFileType {
+			fsa.OpsCheckFile++
+		}
+
+		// Record PID and syscall
+		if fsa.Pids == nil {
+			fsa.Pids = make(map[int]struct{})
+		}
+		fsa.Pids[event.pid] = struct{}{}
+
+		if fsa.Syscalls == nil {
+			fsa.Syscalls = make(map[int]struct{})
+		}
+		fsa.Syscalls[int(event.callNum)] = struct{}{}
+	} else {
+		// Create new record
+		fsa := &FSActivityInfo{
+			OpsAll:       1,
+			OpsCheckFile: 0,
+			Pids:         map[int]struct{}{},
+			Syscalls:     map[int]struct{}{},
+		}
+
+		if handler.SyscallType() == CheckFileType {
+			fsa.OpsCheckFile = 1
+		}
+
+		fsa.Pids[event.pid] = struct{}{}
+		fsa.Syscalls[int(event.callNum)] = struct{}{}
+
+		t.fsActivity[event.pathParam] = fsa
+	}
 }

--- a/tw/pkg/commands/ptrace/tracer.go
+++ b/tw/pkg/commands/ptrace/tracer.go
@@ -1,0 +1,1628 @@
+//go:build linux
+// +build linux
+
+package ptrace
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+
+	"github.com/armon/go-radix"
+	"github.com/chainguard-dev/clog"
+	"golang.org/x/sys/unix"
+)
+
+// AT_FDCWD is the "current working directory" file descriptor
+const AT_FDCWD = -100
+
+// handleSyscall is a shared implementation for handling syscalls across
+// architectures
+func handleSyscall(t *Tracer, pid int) {
+	// Register this tracer for this PID before we access registers
+	// This ensures other threads know we're handling this PID
+	processRegistry.Set(pid, t)
+
+	// Try to get the registers with better error handling
+	var regs unix.PtraceRegs
+	if err := unix.PtraceGetRegs(pid, &regs); err != nil {
+		clog.Debugf("Failed to get registers for PID %d: %v", pid, err)
+
+		// Handle common errors specially
+		if strings.Contains(err.Error(), "no such process") {
+			// Process terminated while we were handling it
+			clog.Infof("Process %d no longer exists, cleaning up", pid)
+			t.statesMu.Lock()
+			delete(t.states, pid)
+			t.statesMu.Unlock()
+
+			processRegistry.Delete(pid)
+
+			select {
+			case t.events <- Event{
+				Type: EventExit,
+				Pid:  pid,
+				Path: fmt.Sprintf("process %d terminated", pid),
+			}:
+				clog.Debugf("sent termination event for %d", pid)
+			default:
+				clog.Warnf("Event channel full, dropping termination event for pid=%d", pid)
+			}
+		} else {
+			// For other errors, try to continue the process to avoid hanging
+			if err := unix.PtraceSyscall(pid, 0); err != nil {
+				// If this also fails with "no such process", the process is gone
+				if strings.Contains(err.Error(), "no such process") {
+					clog.Infof("Process %d terminated during error handling, cleaning up", pid)
+					t.statesMu.Lock()
+					delete(t.states, pid)
+					t.statesMu.Unlock()
+					processRegistry.Delete(pid)
+				} else {
+					clog.Warnf("Failed to continue process after register error: %v", err)
+				}
+			}
+		}
+		return
+	}
+
+	// Use the architecture handler to get the syscall number
+	syscallNum := archHandler.GetSyscallNumber(regs)
+
+	// Get syscall name (doesn't require locking the state)
+	syscallName := getSyscallName(syscallNum)
+
+	// We already registered this tracer for this PID when we called processRegistry.Set
+
+	clog.Debugf("SYSCALL: %s | syscallNum: %d | pid: %d", syscallName, syscallNum, pid)
+
+	// Get processor for this syscall if available
+	processor := GetSyscallProcessor(syscallNum)
+
+	// Acquire state lock to access the pid's state
+	t.statesMu.Lock()
+
+	// Make sure we have a state for this PID
+	state, exists := t.states[pid]
+	if !exists {
+		// Create new state for this PID since it doesn't exist
+		state = &syscallState{
+			pid:          pid,
+			callNum:      syscallNum,
+			expectReturn: true,
+			gotCallNum:   true,
+			fdTable:      make(map[int]FD),
+			childPids:    make(map[int]bool),
+			startTime:    time.Now(),
+		}
+		t.states[pid] = state
+		clog.Debugf("Created new state for PID %d", pid)
+		t.statesMu.Unlock()
+
+		// Handle syscall entry for a new process
+		if processor != nil {
+			clog.Debugf("Calling OnCall for %s (syscallNum=%d) pid=%d",
+				processor.SyscallName(), syscallNum, pid)
+
+			// Make a copy to work with
+			stateCopy := *state
+			processor.OnCall(pid, regs, &stateCopy)
+
+			// Update state with processor results
+			t.statesMu.Lock()
+			if state, ok := t.states[pid]; ok {
+				state.pathParam = stateCopy.pathParam
+				state.pathParamErr = stateCopy.pathParamErr
+				state.dirfd = stateCopy.dirfd
+			}
+
+			// Get values needed for event before releasing lock
+			var eventPath string
+			var dirfd int
+			if st, ok := t.states[pid]; ok {
+				eventPath = st.pathParam
+				dirfd = st.dirfd
+			}
+			t.statesMu.Unlock()
+
+			// Generate event for syscalls that do this on call rather than return
+			if processor.EventOnCall() {
+				if dirfd != 0 && dirfd != AT_FDCWD {
+					eventPath = t.resolvePath(pid, eventPath, dirfd)
+				}
+
+				// Send event non-blocking to avoid deadlocks
+				select {
+				case t.events <- Event{
+					Type:        EventSyscall,
+					Syscall:     syscallNum,
+					SyscallName: syscallName,
+					Pid:         pid,
+					Path:        eventPath,
+				}:
+					// Event sent successfully
+					clog.Debugf("Sent event for %s (pid=%d)", syscallName, pid)
+				default:
+					// Channel is full, log warning and continue
+					clog.Warnf("Event channel full, dropping event for syscall %s", syscallName)
+				}
+			}
+		} else {
+			// Re-acquire lock for the fallback handler
+			t.statesMu.Lock()
+			if st, ok := t.states[pid]; ok {
+				state = st
+			}
+			t.statesMu.Unlock()
+
+			// Fallback for syscalls without processors
+			handleSyscallEnter(t, pid, syscallNum, syscallName, regs, state)
+		}
+	} else if state.expectReturn {
+		// This is syscall exit
+		retVal := archHandler.CallReturnValue(regs)
+
+		// Update state for syscall return
+		state.retVal = retVal
+		state.gotRetVal = true
+
+		// Make copies of needed values before modifying state
+		eventPath := state.pathParam
+		dirfd := state.dirfd
+		callNum := state.callNum
+		pathParamErr := state.pathParamErr
+
+		// Reset state for next syscall
+		state.expectReturn = false
+		state.callNum = 0
+		state.pathParam = ""
+		state.pathParamErr = nil
+		state.dirfd = 0
+
+		// Release lock after updating state
+		t.statesMu.Unlock()
+
+		// Handle syscall exit
+		if processor != nil {
+			clog.Debugf("Calling OnReturn for %s (syscallNum=%d) pid=%d",
+				processor.SyscallName(), syscallNum, pid)
+
+			// Create a working copy with needed values restored
+			stateCopy := syscallState{
+				pid:          pid,
+				callNum:      callNum,
+				retVal:       retVal,
+				gotRetVal:    true,
+				pathParam:    eventPath,
+				pathParamErr: pathParamErr,
+				dirfd:        dirfd,
+				fdTable:      make(map[int]FD), // Create a new map to avoid modifying the original
+			}
+
+			// Copy relevant parts of fdTable if needed by processor
+			t.statesMu.RLock()
+			if st, ok := t.states[pid]; ok {
+				for k, v := range st.fdTable {
+					stateCopy.fdTable[k] = v
+				}
+			}
+			t.statesMu.RUnlock()
+
+			// Call processor with our copy
+			processor.OnReturn(pid, regs, &stateCopy)
+
+			// Send event if needed
+			if !processor.EventOnCall() && pathParamErr == nil {
+				if dirfd != 0 && dirfd != AT_FDCWD {
+					eventPath = t.resolvePath(pid, eventPath, dirfd)
+				}
+
+				// Non-blocking send to avoid deadlocks
+				select {
+				case t.events <- Event{
+					Type:        EventSyscall,
+					Syscall:     callNum,
+					SyscallName: syscallName + "-return",
+					Pid:         pid,
+					Path:        eventPath,
+					ReturnVal:   int64(retVal),
+				}:
+					// Event sent successfully
+					clog.Debugf("Sent return event for %s (pid=%d)", syscallName, pid)
+				default:
+					// Channel is full, log warning and continue
+					clog.Warnf("Event channel full, dropping return event for syscall %s", syscallName)
+				}
+			}
+
+			// Check if processor updated fdTable and merge changes back if needed
+			// This avoids losing file descriptor information
+			t.statesMu.Lock()
+			if st, ok := t.states[pid]; ok {
+				// Merge any new fds processor might have added
+				for fdNum, fdInfo := range stateCopy.fdTable {
+					if _, exists := st.fdTable[fdNum]; !exists {
+						st.fdTable[fdNum] = fdInfo
+					}
+				}
+			}
+			t.statesMu.Unlock()
+		} else {
+			// Get a fresh copy of state for the fallback handler
+			t.statesMu.Lock()
+			if st, ok := t.states[pid]; ok {
+				// Restore needed values in the state
+				st.callNum = callNum
+				st.retVal = retVal
+				st.gotRetVal = true
+				state = st
+			}
+			t.statesMu.Unlock()
+
+			// Fallback for syscalls without processors
+			handleSyscallExit(t, pid, regs, state, syscallName)
+		}
+	} else {
+		// This is a new syscall after a completed one
+		state.callNum = syscallNum
+		state.expectReturn = true
+		state.gotCallNum = true
+		state.gotRetVal = false
+		t.statesMu.Unlock()
+
+		// Call recursively to handle the new syscall
+		// This is safe because we updated the state before releasing the lock
+		handleSyscall(t, pid)
+	}
+}
+
+// handleSyscallEnter handles the common syscall entry logic
+func handleSyscallEnter(t *Tracer, pid int, syscallNum uint32, syscallName string, regs unix.PtraceRegs, state *syscallState) {
+	// Function to safely send events with non-blocking behavior
+	sendEvent := func(event Event) {
+		select {
+		case t.events <- event:
+			// Event sent successfully
+			clog.Debugf("Sent event for %s (pid=%d)", event.SyscallName, event.Pid)
+		default:
+			// Channel is full, log warning and continue
+			clog.Warnf("Event channel full, dropping event for syscall %s", event.SyscallName)
+		}
+	}
+
+	switch syscallNum {
+	case unix.SYS_READ, unix.SYS_PREAD64:
+		fd := archHandler.CallFirstParam(regs)
+		bufSize := archHandler.CallThirdParam(regs)
+
+		// Try to get the file path associated with this fd
+		path := fmt.Sprintf("fd: %d", fd)
+
+		// Create a safe copy of the fdTable to avoid locking during event processing
+		fdPath := ""
+		t.statesMu.RLock()
+		if state != nil {
+			if fdInfo, ok := state.fdTable[int(fd)]; ok {
+				fdPath = fdInfo.Path
+			}
+		}
+		t.statesMu.RUnlock()
+
+		if fdPath != "" {
+			path = fmt.Sprintf("fd: %d (%s)", fd, fdPath)
+		}
+
+		sendEvent(Event{
+			Type:        EventSyscall,
+			Syscall:     syscallNum,
+			SyscallName: syscallName,
+			Pid:         pid,
+			Path:        fmt.Sprintf("%s, size: %d bytes", path, bufSize),
+		})
+
+	case unix.SYS_WRITE, unix.SYS_PWRITE64:
+		fd := archHandler.CallFirstParam(regs)
+		bufSize := archHandler.CallThirdParam(regs)
+
+		// Try to get the file path associated with this fd
+		path := fmt.Sprintf("fd: %d", fd)
+
+		// Get FD info safely
+		fdPath := ""
+		t.statesMu.RLock()
+		if state != nil && state.fdTable != nil {
+			if fdInfo, ok := state.fdTable[int(fd)]; ok {
+				fdPath = fdInfo.Path
+			}
+		}
+		t.statesMu.RUnlock()
+
+		if fdPath != "" {
+			path = fmt.Sprintf("fd: %d (%s)", fd, fdPath)
+		}
+
+		sendEvent(Event{
+			Type:        EventSyscall,
+			Syscall:     syscallNum,
+			SyscallName: syscallName,
+			Pid:         pid,
+			Path:        fmt.Sprintf("%s, size: %d bytes", path, bufSize),
+		})
+
+	case unix.SYS_CLOSE:
+		fd := archHandler.CallFirstParam(regs)
+
+		// Try to get the file path associated with this fd
+		path := fmt.Sprintf("fd: %d", fd)
+		fdPath := ""
+
+		t.statesMu.Lock()
+		if state != nil && state.fdTable != nil {
+			if fdInfo, ok := state.fdTable[int(fd)]; ok {
+				fdPath = fdInfo.Path
+				// Store the fd being closed for use in return
+				state.pathParam = fdInfo.Path
+			}
+		}
+		t.statesMu.Unlock()
+
+		if fdPath != "" {
+			path = fmt.Sprintf("fd: %d (%s)", fd, fdPath)
+		}
+
+		sendEvent(Event{
+			Type:        EventSyscall,
+			Syscall:     syscallNum,
+			SyscallName: syscallName,
+			Pid:         pid,
+			Path:        path,
+		})
+
+	case unix.SYS_SOCKET, unix.SYS_CONNECT, unix.SYS_BIND, unix.SYS_LISTEN:
+		domain := archHandler.CallFirstParam(regs)
+		sockType := archHandler.CallSecondParam(regs)
+		protocol := archHandler.CallThirdParam(regs)
+
+		sendEvent(Event{
+			Type:        EventSyscall,
+			Syscall:     syscallNum,
+			SyscallName: syscallName,
+			Pid:         pid,
+			Path:        fmt.Sprintf("domain: %d, type: %d, protocol: %d", domain, sockType, protocol),
+		})
+
+	case unix.SYS_ACCEPT, unix.SYS_ACCEPT4:
+		sockfd := archHandler.CallFirstParam(regs)
+
+		sendEvent(Event{
+			Type:        EventSyscall,
+			Syscall:     syscallNum,
+			SyscallName: syscallName,
+			Pid:         pid,
+			Path:        fmt.Sprintf("sockfd: %d", sockfd),
+		})
+
+	case unix.SYS_MMAP:
+		length := archHandler.CallSecondParam(regs)
+		prot := archHandler.CallThirdParam(regs)
+		flags := archHandler.CallFourthParam(regs)
+
+		sendEvent(Event{
+			Type:        EventSyscall,
+			Syscall:     syscallNum,
+			SyscallName: syscallName,
+			Pid:         pid,
+			Path:        fmt.Sprintf("length: %d, prot: 0x%x, flags: 0x%x", length, prot, flags),
+		})
+
+	case unix.SYS_CHDIR:
+		pathAddr := archHandler.CallFirstParam(regs)
+		if path, err := getStringParam(pid, pathAddr); err == nil && path != "" {
+			// Update state in a single lock acquisition
+			t.statesMu.Lock()
+			if state != nil {
+				state.pathParam = path
+
+				// Update the process's current working directory
+				if filepath.IsAbs(path) {
+					state.cwd = path
+				} else {
+					// Make sure cwd is initialized
+					if state.cwd == "" {
+						// Try to get cwd from /proc if available
+						if cwd, err := os.Readlink(fmt.Sprintf("/proc/%d/cwd", pid)); err == nil {
+							state.cwd = cwd
+						} else {
+							// Default to current directory
+							if wd, err := os.Getwd(); err == nil {
+								state.cwd = wd
+							} else {
+								state.cwd = "/"
+							}
+						}
+					}
+					state.cwd = filepath.Clean(filepath.Join(state.cwd, path))
+				}
+			}
+			t.statesMu.Unlock()
+
+			sendEvent(Event{
+				Type:        EventSyscall,
+				Syscall:     syscallNum,
+				SyscallName: syscallName,
+				Pid:         pid,
+				Path:        path,
+			})
+		}
+	}
+}
+
+// handleSyscallExit handles the common syscall exit logic
+func handleSyscallExit(t *Tracer, pid int, regs unix.PtraceRegs, state *syscallState, syscallName string) {
+	// Function to safely send events with non-blocking behavior
+	sendEvent := func(event Event) {
+		select {
+		case t.events <- event:
+			// Event sent successfully
+			clog.Debugf("Sent return event for %s (pid=%d)", event.SyscallName, event.Pid)
+		default:
+			// Channel is full, log warning and continue
+			clog.Warnf("Event channel full, dropping return event for syscall %s", event.SyscallName)
+		}
+	}
+
+	// Safely get values we need from state
+	var callNum uint32
+	var pathParam string
+
+	// We need to be careful as state could be null if process terminated
+	if state != nil {
+		t.statesMu.RLock()
+		callNum = state.callNum
+		pathParam = state.pathParam
+		t.statesMu.RUnlock()
+	} else {
+		// If state is null, use syscall number from regs
+		callNum = archHandler.GetSyscallNumber(regs)
+	}
+
+	retVal := archHandler.CallReturnValue(regs)
+	sretVal := int64(retVal)
+
+	switch callNum {
+	case unix.SYS_READ, unix.SYS_PREAD64, unix.SYS_WRITE, unix.SYS_PWRITE64:
+		if sretVal >= 0 {
+			sendEvent(Event{
+				Type:        EventSyscall,
+				Syscall:     callNum,
+				SyscallName: getSyscallName(callNum) + "-return",
+				Pid:         pid,
+				Path:        fmt.Sprintf("returned %d bytes", sretVal),
+				ReturnVal:   sretVal,
+			})
+		} else {
+			sendEvent(Event{
+				Type:        EventSyscall,
+				Syscall:     callNum,
+				SyscallName: getSyscallName(callNum) + "-return",
+				Pid:         pid,
+				Path:        fmt.Sprintf("error: %d", -sretVal),
+				ReturnVal:   sretVal,
+			})
+		}
+
+	case unix.SYS_CLOSE:
+		fdVal := archHandler.CallFirstParam(regs)
+		// Remove from file descriptor table if successful
+		if sretVal == 0 && pathParam != "" && state != nil {
+			t.statesMu.Lock()
+			if state.fdTable != nil {
+				delete(state.fdTable, int(fdVal))
+			}
+			t.statesMu.Unlock()
+		}
+
+		sendEvent(Event{
+			Type:        EventSyscall,
+			Syscall:     callNum,
+			SyscallName: getSyscallName(callNum) + "-return",
+			Pid:         pid,
+			Path:        fmt.Sprintf("returned %d", sretVal),
+			ReturnVal:   sretVal,
+		})
+
+	case unix.SYS_CONNECT, unix.SYS_BIND, unix.SYS_SOCKET:
+		if sretVal >= 0 {
+			// For socket() specifically, add the file descriptor
+			if callNum == unix.SYS_SOCKET {
+				t.statesMu.Lock()
+				if state != nil && state.fdTable != nil {
+					state.fdTable[int(sretVal)] = FD{
+						Path:     fmt.Sprintf("<socket:%d>", sretVal),
+						Type:     "socket",
+						OpenTime: time.Now(),
+					}
+				}
+				t.statesMu.Unlock()
+			}
+
+			sendEvent(Event{
+				Type:        EventSyscall,
+				Syscall:     callNum,
+				SyscallName: getSyscallName(callNum) + "-return",
+				Pid:         pid,
+				Path:        fmt.Sprintf("success: fd %d", sretVal),
+				ReturnVal:   sretVal,
+			})
+		} else {
+			sendEvent(Event{
+				Type:        EventSyscall,
+				Syscall:     callNum,
+				SyscallName: getSyscallName(callNum) + "-return",
+				Pid:         pid,
+				Path:        fmt.Sprintf("error: %d", -sretVal),
+				ReturnVal:   sretVal,
+			})
+		}
+
+	case unix.SYS_DUP, unix.SYS_DUP3:
+		// Handle file descriptor duplication
+		if sretVal >= 0 {
+			// Get the source fd
+			srcFd := int(archHandler.CallFirstParam(regs))
+			newFd := int(sretVal)
+
+			// Copy file descriptor info if available
+			t.statesMu.Lock()
+			if state != nil && state.fdTable != nil {
+				if srcFdInfo, ok := state.fdTable[srcFd]; ok {
+					state.fdTable[newFd] = FD{
+						Path:     srcFdInfo.Path,
+						Type:     srcFdInfo.Type,
+						OpenTime: time.Now(),
+					}
+				}
+			}
+			t.statesMu.Unlock()
+
+			sendEvent(Event{
+				Type:        EventSyscall,
+				Syscall:     callNum,
+				SyscallName: getSyscallName(callNum) + "-return",
+				Pid:         pid,
+				Path:        fmt.Sprintf("dup %d -> %d", srcFd, newFd),
+				ReturnVal:   sretVal,
+			})
+		}
+	}
+}
+
+type Event struct {
+	Type        EventType
+	Syscall     uint32
+	SyscallName string
+	Pid         int
+	Path        string
+	ReturnVal   int64
+}
+
+type SyscallEvent struct {
+	Regs     unix.PtraceRegs
+	Sysno    int
+	Args     SyscallArgument
+	Ret      [2]SyscallArgument
+	Errno    unix.Errno
+	Duration time.Duration
+}
+
+type SyscallArguments [6]SyscallArgument
+
+type SyscallArgument struct {
+	Value uintptr
+}
+
+type EventType int
+
+const (
+	EventSyscall EventType = iota
+	EventFork
+	EventExec
+	EventExit
+)
+
+// FSActivity represents information about file system activity
+type FSActivity struct {
+	Ops           int              // Total operations on this path
+	OpsRead       int              // Read operations
+	OpsWrite      int              // Write operations
+	OpsExec       int              // Execution operations
+	OpsCheckFile  int              // File check operations (stat, access, etc.)
+	OpsOpenFile   int              // File open operations
+	Pids          map[int]struct{} // Set of PIDs that accessed this path
+	Syscalls      map[int]struct{} // Set of syscalls used to access this path
+	IsSubdir      bool             // Whether this path is a subdirectory of another tracked path
+	LastOperation time.Time        // Last time this path was accessed
+}
+
+// FSActivityType categorizes the types of file system operations
+type FSActivityType string
+
+const (
+	// Operation type constants
+	FSActivityTypeRead      FSActivityType = "read"
+	FSActivityTypeWrite     FSActivityType = "write"
+	FSActivityTypeExec      FSActivityType = "exec"
+	FSActivityTypeCheckFile FSActivityType = "check"
+	FSActivityTypeOpenFile  FSActivityType = "open"
+)
+
+// FSActivityTracker tracks file system activity using a radix tree for efficient
+// path-based lookups and prefix searching
+type FSActivityTracker struct {
+	tree         *radix.Tree
+	includeNew   bool                // Whether to include new paths not in origPaths
+	origPaths    map[string]struct{} // Original paths to track
+	skipPrefixes []string            // Path prefixes to skip (e.g., /proc/, /sys/, /dev/)
+	mu           sync.RWMutex        // For thread-safe access to the tree
+}
+
+// NewFSActivityTracker creates a new file system activity tracker
+func NewFSActivityTracker() *FSActivityTracker {
+	return &FSActivityTracker{
+		tree:         radix.New(),
+		includeNew:   true, // Default to including all paths
+		origPaths:    make(map[string]struct{}),
+		skipPrefixes: []string{"/proc/", "/sys/", "/dev/"},
+	}
+}
+
+// SetPathFiltering configures whether to include only original paths or all new paths
+func (f *FSActivityTracker) SetPathFiltering(includeNew bool, origPaths map[string]struct{}) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	f.includeNew = includeNew
+	f.origPaths = origPaths
+}
+
+// ShouldTrackPath determines if a path should be tracked based on filtering rules
+func (f *FSActivityTracker) ShouldTrackPath(path string) bool {
+	// Skip if path is in skip prefixes
+	for _, prefix := range f.skipPrefixes {
+		if strings.HasPrefix(path, prefix) {
+			return false
+		}
+	}
+
+	// Skip "." since it's not useful
+	if path == "." {
+		return false
+	}
+
+	// If including all new paths, accept all non-skipped paths
+	if f.includeNew {
+		return true
+	}
+
+	// Otherwise, check if it's in original paths
+	f.mu.RLock()
+	_, ok := f.origPaths[path]
+	f.mu.RUnlock()
+	return ok
+}
+
+// AddActivity records file system activity for a path
+func (f *FSActivityTracker) AddActivity(path string, pid int, syscallNum int, opType FSActivityType) {
+	// Clean and normalize the path
+	path = filepath.Clean(path)
+
+	// Check if we should track this path
+	if !f.ShouldTrackPath(path) {
+		return
+	}
+
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	// Get or create activity record
+	raw, found := f.tree.Get(path)
+	var activity *FSActivity
+	if !found {
+		activity = &FSActivity{
+			Pids:     make(map[int]struct{}),
+			Syscalls: make(map[int]struct{}),
+		}
+	} else {
+		activity = raw.(*FSActivity)
+	}
+
+	// Update activity information
+	activity.Ops++
+	activity.Pids[pid] = struct{}{}
+	activity.Syscalls[syscallNum] = struct{}{}
+	activity.LastOperation = time.Now()
+
+	// Update operation type counts
+	switch opType {
+	case FSActivityTypeRead:
+		activity.OpsRead++
+	case FSActivityTypeWrite:
+		activity.OpsWrite++
+	case FSActivityTypeExec:
+		activity.OpsExec++
+	case FSActivityTypeCheckFile:
+		activity.OpsCheckFile++
+	case FSActivityTypeOpenFile:
+		activity.OpsOpenFile++
+	}
+
+	// Store the updated activity
+	f.tree.Insert(path, activity)
+}
+
+// GetActivityMap returns a map of all file system activity
+// with subdirectory information calculated, filtering out subdirectories
+func (f *FSActivityTracker) GetActivityMap() map[string]*FSActivity {
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+
+	// Mark subdirectories
+	f.tree.Walk(func(key string, value interface{}) bool {
+		value.(*FSActivity).IsSubdir = false // Reset first
+
+		// Check if this key is a prefix of any other keys
+		f.tree.WalkPrefix(key, func(subkey string, subvalue interface{}) bool {
+			if subkey != key && filepath.Dir(subkey) == key {
+				subvalue.(*FSActivity).IsSubdir = true
+			}
+			return false
+		})
+		return false
+	})
+
+	// Build the result map, excluding subdirectories
+	result := make(map[string]*FSActivity)
+	f.tree.Walk(func(key string, value interface{}) bool {
+		activity := value.(*FSActivity)
+		if !activity.IsSubdir {
+			result[key] = activity
+		}
+		return false
+	})
+
+	return result
+}
+
+type Tracer struct {
+	args            []string
+	cmd             *exec.Cmd
+	events          chan Event
+	done            chan struct{}
+	running         bool
+	statesMu        sync.RWMutex
+	states          map[int]*syscallState
+	fsTracker       *FSActivityTracker
+	opts            TracerOpts
+	collectorDoneCh chan int
+}
+
+type TracerOpts struct {
+	Name string
+	Args []string
+}
+
+// GetFileSystemActivity returns the file system activity tracked by this tracer
+func (t *Tracer) GetFileSystemActivity() map[string]*FSActivity {
+	return t.fsTracker.GetActivityMap()
+}
+
+func New(args []string, opts TracerOpts) (*Tracer, error) {
+	return &Tracer{
+		args:            args,
+		events:          make(chan Event, 10000),
+		done:            make(chan struct{}),
+		running:         false,
+		states:          make(map[int]*syscallState),
+		fsTracker:       NewFSActivityTracker(),
+		collectorDoneCh: make(chan int, 2),
+		opts:            opts,
+	}, nil
+}
+
+func (t *Tracer) Start(ctx context.Context) error {
+	if t.running {
+		return fmt.Errorf("tracer is already running")
+	}
+	t.running = true
+
+	cmd := exec.CommandContext(ctx, t.args[0], t.args[1:]...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	cmd.SysProcAttr = &unix.SysProcAttr{
+		Ptrace:  true,
+		Setpgid: true,
+	}
+
+	if err := cmd.Start(); err != nil {
+		t.running = false
+		return fmt.Errorf("failed to start command: %w", err)
+	}
+
+	t.cmd = cmd
+	mainPid := cmd.Process.Pid
+	clog.Infof("Started process with PID %d", mainPid)
+
+	// Wait for the first TRAP which indicates the process is stopped and ready to be traced
+	var ws unix.WaitStatus
+	pid, err := unix.Wait4(mainPid, &ws, 0, nil)
+	if err != nil {
+		t.running = false
+		return fmt.Errorf("failed to wait for initial trap: %w", err)
+	}
+
+	clog.Infof("Process initial status: pid=%d, status=%v (Exited=%v, Signaled=%v, Stopped=%v, StopSignal=%v, TrapCause=%v)",
+		pid, ws, ws.Exited(), ws.Signaled(), ws.Stopped(), ws.StopSignal(), ws.TrapCause())
+
+	if !ws.Stopped() {
+		t.running = false
+		return fmt.Errorf("process not stopped after start (pid=%d, status=%v)", pid, ws)
+	}
+
+	clog.Infof("Process stopped for tracing (pid=%d, signal=%v)", pid, ws.StopSignal())
+
+	// Configure tracing options
+	const ptOpts = unix.PTRACE_O_TRACECLONE |
+		unix.PTRACE_O_TRACEFORK |
+		unix.PTRACE_O_TRACEVFORK |
+		unix.PTRACE_O_TRACEEXEC |
+		unix.PTRACE_O_TRACESYSGOOD |
+		unix.PTRACE_O_TRACEEXIT |
+		unix.PTRACE_O_EXITKILL
+
+	if err := unix.PtraceSetOptions(mainPid, ptOpts); err != nil {
+		t.running = false
+		return fmt.Errorf("failed to set ptrace options: %w", err)
+	}
+
+	// Verify the process is still alive
+	if err := unix.Kill(mainPid, 0); err != nil {
+		t.running = false
+		return fmt.Errorf("process died after setting ptrace options: %w", err)
+	}
+
+	// Initialize the tracer's state map with the first process
+	cwd, _ := os.Getwd()
+	initialState := &syscallState{
+		pid:       mainPid,
+		cwd:       cwd,
+		fdTable:   make(map[int]FD),
+		childPids: make(map[int]bool),
+		startTime: time.Now(),
+		started:   true, // Mark as started immediately
+	}
+
+	t.statesMu.Lock()
+	t.states[mainPid] = initialState
+	t.statesMu.Unlock()
+
+	go t.processEvents(ctx)
+
+	if err := unix.PtraceSyscall(mainPid, 0); err != nil {
+		t.running = false
+		return fmt.Errorf("failed to set initial syscall trace: %w", err)
+	}
+
+	// Start the tracing goroutine
+	go t.trace(ctx, cmd)
+	return nil
+}
+
+func (t *Tracer) Wait() <-chan struct{} {
+	return t.done
+}
+
+func (t *Tracer) Events() <-chan Event {
+	return t.events
+}
+
+func (t *Tracer) Stop() {
+	t.running = false
+}
+
+// syscallState tracks the state of a syscall being processed
+type syscallState struct {
+	pid          int          // Process ID
+	callNum      uint32       // System call number
+	retVal       uint64       // Return value from syscall
+	expectReturn bool         // Whether we're expecting a return from this syscall
+	gotCallNum   bool         // Whether we've gotten the syscall number
+	gotRetVal    bool         // Whether we've gotten the return value
+	started      bool         // Whether the process has started
+	exiting      bool         // Whether the process is exiting
+	pathParam    string       // Path parameter for syscalls that operate on paths
+	pathParamErr error        // Error when retrieving path parameter
+	dirfd        int          // Tracks directory file descriptor for *at syscalls
+	cwd          string       // Current working directory of the process
+	fdTable      map[int]FD   // Maps file descriptors to their paths
+	parentPid    int          // Parent process ID
+	childPids    map[int]bool // Child process IDs
+	startTime    time.Time    // Process start time
+}
+
+// FD represents a file descriptor and its associated information
+type FD struct {
+	Path     string // The path this file descriptor refers to
+	Type     string // Type of file descriptor (regular, socket, pipe, etc)
+	OpenTime time.Time
+}
+
+func (t *Tracer) trace(ctx context.Context, cmd *exec.Cmd) {
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
+	// Correctly handle cleanup but avoid sleep-based synchronization
+	defer func() {
+		clog.InfoContext(ctx, "Trace function exiting")
+		close(t.events)
+		close(t.done)
+	}()
+
+	// Get current working directory at the start
+	cwd, err := os.Getwd()
+	if err != nil {
+		cwd = "/" // Default to root if we can't get current directory
+		clog.ErrorContextf(ctx, "failed to get current working directory: %v", err)
+	}
+
+	// Process group handling
+	mainPid := cmd.Process.Pid
+	pgid, err := unix.Getpgid(mainPid)
+	if err != nil {
+		clog.ErrorContextf(ctx, "failed to get process group ID: %v", err)
+		// Continue anyway, we'll just track individual processes
+	} else {
+		clog.InfoContextf(ctx, "tracking process group ID: %d", pgid)
+	}
+
+	// Initialize state tracking based on your implementation
+	mainExiting := false
+	_ = mainExiting
+	waitFor := mainPid
+	callSig := 0 // No signal initially
+
+	// Initialize process state similar to your implementation
+	t.statesMu.Lock()
+	if _, exists := t.states[mainPid]; !exists {
+		// In case it wasn't initialized yet
+		t.states[mainPid] = &syscallState{
+			pid:       mainPid,
+			cwd:       cwd,
+			fdTable:   make(map[int]FD),
+			childPids: make(map[int]bool),
+			startTime: time.Now(),
+			started:   true,
+		}
+	}
+	t.statesMu.Unlock()
+
+	for {
+		select {
+		case <-ctx.Done():
+			clog.InfoContext(ctx, "context done, exiting tracer")
+			return
+		default:
+			// Continue with syscall tracing, matching your implementation style
+			clog.DebugContextf(ctx, "trace syscall (pid=%v sig=%v)", waitFor, callSig)
+			err := unix.PtraceSyscall(waitFor, callSig)
+			if err != nil {
+				if strings.Contains(err.Error(), "no such process") {
+					// Process might have terminated very quickly
+					clog.Debugf("PtraceSyscall: Process %d no longer exists", waitFor)
+
+					// If this was the main process and we're just starting
+					if waitFor == mainPid {
+						clog.Warnf("Main process %d terminated very quickly after initial stop", mainPid)
+
+						// Check if process actually exists via /proc
+						_, procErr := os.Stat(fmt.Sprintf("/proc/%d", mainPid))
+						if procErr != nil && os.IsNotExist(procErr) {
+							clog.Infof("Confirmed main process %d no longer exists", mainPid)
+							// Report exit
+							select {
+							case t.events <- Event{
+								Type:        EventExit,
+								Pid:         mainPid,
+								SyscallName: "exit",
+								Path:        fmt.Sprintf("process %d exited very quickly", mainPid),
+							}:
+							default:
+								clog.Warnf("Failed to send exit event, channel full")
+							}
+
+							select {
+							case t.done <- struct{}{}:
+							default:
+							}
+							return
+						}
+					}
+
+					// Try waiting for any process instead
+					waitFor = -1
+					continue
+				} else {
+					clog.ErrorContextf(ctx, "failed to syscall ptrace syscall: %v", err)
+				}
+			}
+			callSig = 0 // Reset signal after use
+
+			// Wait for syscall or other ptrace events
+			var ws unix.WaitStatus
+			wpid, err := unix.Wait4(waitFor, &ws, unix.WALL, nil)
+
+			// Additional debug for first loop iteration
+			if waitFor == mainPid {
+				clog.Debugf("First wait4 after stop - result: pid=%d, error=%v, status=%v",
+					wpid, err, ws)
+			}
+
+			if err != nil {
+				if err == unix.ECHILD {
+					clog.InfoContext(ctx, "no more child processes")
+					return
+				}
+				clog.Warnf("wait4 error: %v (errno=%d)", err, err.(syscall.Errno))
+
+				// If this was the first wait for main PID, handle specially
+				if waitFor == mainPid {
+					clog.Warnf("Error waiting for main PID on first trace iteration")
+					// Check if process exists
+					_, procErr := os.Stat(fmt.Sprintf("/proc/%d", mainPid))
+					if procErr != nil && os.IsNotExist(procErr) {
+						clog.Infof("Main process %d no longer exists after first start", mainPid)
+						// Report exit and terminate
+						t.events <- Event{
+							Type:        EventExit,
+							Pid:         mainPid,
+							SyscallName: "exit",
+							Path:        "main process exited immediately",
+						}
+						select {
+						case t.done <- struct{}{}:
+						default:
+						}
+						return
+					}
+				}
+				waitFor = -1
+				continue
+			}
+
+			// Debug output for event type
+			eventType := "unknown"
+			if ws.Exited() {
+				eventType = "exited"
+			} else if ws.Signaled() {
+				eventType = "signaled"
+			} else if ws.Stopped() {
+				eventType = "stopped"
+			}
+			clog.DebugContextf(ctx, "wait4 => pid=%d event=%s status=%d", wpid, eventType, ws)
+
+			// Handle the event based on type
+			if ws.Exited() {
+				// Process exited normally
+				exitStatus := ws.ExitStatus()
+				clog.InfoContextf(ctx, "process %d exited with status: %d", wpid, exitStatus)
+
+				// Clean up from registry and state tracking
+				processRegistry.Delete(wpid)
+
+				// Clean up our states map
+				t.statesMu.Lock()
+				// Update parent to remove this child if known
+				if state, exists := t.states[wpid]; exists && state.parentPid != 0 {
+					if parentState, parentExists := t.states[state.parentPid]; parentExists {
+						delete(parentState.childPids, wpid)
+					}
+				}
+
+				// Remove the process from our tracked states
+				delete(t.states, wpid)
+
+				// Check if this was the main process
+				if wpid == mainPid {
+					mainExiting = true
+					clog.InfoContext(ctx, "main process exited")
+				}
+
+				// Exit if no more processes to track
+				hasProcesses := len(t.states) > 0
+				t.statesMu.Unlock()
+
+				if !hasProcesses {
+					clog.InfoContext(ctx, "all processes exited, stopping tracer")
+					return
+				}
+
+				waitFor = -1 // Wait for any process
+				continue
+			}
+
+			if ws.Signaled() {
+				// Process terminated by signal
+				signum := ws.Signal()
+				clog.InfoContextf(ctx, "process %d terminated by signal: %v", wpid, signum)
+
+				// Clean up state
+				processRegistry.Delete(wpid)
+
+				t.statesMu.Lock()
+				delete(t.states, wpid)
+
+				if wpid == mainPid {
+					mainExiting = true
+				}
+
+				hasProcesses := len(t.states) > 0
+				t.statesMu.Unlock()
+
+				if !hasProcesses {
+					clog.InfoContext(ctx, "all processes exited, stopping tracer")
+					return
+				}
+
+				waitFor = -1
+				continue
+			}
+
+			if ws.Stopped() {
+				sig := ws.StopSignal()
+				trapCause := ws.TrapCause()
+
+				// Handle different stop causes
+				if (sig == unix.SIGTRAP) && ((trapCause&0xff) == unix.PTRACE_EVENT_CLONE ||
+					(trapCause&0xff) == unix.PTRACE_EVENT_FORK ||
+					(trapCause&0xff) == unix.PTRACE_EVENT_VFORK) {
+
+					// Handle new process creation
+					newPid, err := unix.PtraceGetEventMsg(wpid)
+					if err != nil {
+						clog.ErrorContextf(ctx, "failed to get event message for clone/fork: %v", err)
+					} else {
+						newPidInt := int(newPid)
+						clog.InfoContextf(ctx, "new process created: parent=%d child=%d", wpid, newPidInt)
+
+						// Create state for the new process
+						t.statesMu.Lock()
+						if parentState, exists := t.states[wpid]; exists {
+							// Copy parent's state for child
+							childState := &syscallState{
+								pid:       newPidInt,
+								parentPid: wpid,
+								cwd:       parentState.cwd,
+								fdTable:   make(map[int]FD),
+								childPids: make(map[int]bool),
+								startTime: time.Now(),
+							}
+
+							// Copy FDs from parent
+							for fd, info := range parentState.fdTable {
+								childState.fdTable[fd] = info
+							}
+
+							// Add to tracking
+							t.states[newPidInt] = childState
+
+							// Add to parent's children
+							parentState.childPids[newPidInt] = true
+						} else {
+							// Parent not found, create minimal state
+							t.states[newPidInt] = &syscallState{
+								pid:       newPidInt,
+								parentPid: wpid,
+								fdTable:   make(map[int]FD),
+								childPids: make(map[int]bool),
+								startTime: time.Now(),
+							}
+						}
+						t.statesMu.Unlock()
+					}
+
+					// Continue process
+					if err := unix.PtraceSyscall(wpid, 0); err != nil {
+						clog.ErrorContextf(ctx, "failed to continue process after clone/fork: %v", err)
+					}
+
+					waitFor = -1 // Wait for any process
+					continue
+				}
+
+				// Handle exec events
+				if (sig == unix.SIGTRAP) && ((trapCause & 0xff) == unix.PTRACE_EVENT_EXEC) {
+					clog.InfoContextf(ctx, "process %d executed a new program", wpid)
+
+					// Update state for exec'd process
+					t.statesMu.Lock()
+					if state, exists := t.states[wpid]; exists {
+						// Reset file descriptors except stdin/stdout/stderr
+						newFdTable := make(map[int]FD)
+						for fd := 0; fd <= 2; fd++ {
+							if oldFd, hasOld := state.fdTable[fd]; hasOld {
+								newFdTable[fd] = oldFd
+							}
+						}
+						state.fdTable = newFdTable
+
+						// Try to update working directory
+						if procCwd, err := os.Readlink(fmt.Sprintf("/proc/%d/cwd", wpid)); err == nil {
+							state.cwd = procCwd
+						}
+					}
+					t.statesMu.Unlock()
+
+					// Continue process
+					if err := unix.PtraceSyscall(wpid, 0); err != nil {
+						clog.ErrorContextf(ctx, "failed to continue process after exec: %v", err)
+					}
+
+					waitFor = -1
+					continue
+				}
+
+				// Handle exit notifications
+				if (sig == unix.SIGTRAP) && ((trapCause & 0xff) == unix.PTRACE_EVENT_EXIT) {
+					t.statesMu.Lock()
+					if state, exists := t.states[wpid]; exists {
+						state.exiting = true
+					}
+					t.statesMu.Unlock()
+
+					clog.InfoContextf(ctx, "process %d is about to exit", wpid)
+
+					if wpid == mainPid {
+						mainExiting = true
+						clog.InfoContext(ctx, "main process is about to exit")
+					}
+
+					// Continue the process to let it exit
+					if err := unix.PtraceSyscall(wpid, 0); err != nil {
+						clog.ErrorContextf(ctx, "failed to continue exiting process: %v", err)
+					}
+
+					waitFor = -1
+					continue
+				}
+
+				// Handle syscall stop
+				if sig == unix.SIGTRAP|0x80 {
+					// Process syscall
+					handleSyscall(t, wpid)
+
+					// Continue with syscall tracing
+					if err := unix.PtraceSyscall(wpid, 0); err != nil {
+						if strings.Contains(err.Error(), "no such process") {
+							// Process might have terminated between wait4 and here
+							clog.DebugContextf(ctx, "process no longer exists pid=%v", wpid)
+						} else {
+							clog.ErrorContextf(ctx, "failed to continue process after syscall: %v", err)
+						}
+					}
+
+					waitFor = -1
+					continue
+				}
+
+				// Forward other stop signals to the process
+				callSig = int(sig)
+				if err := unix.PtraceSyscall(wpid, callSig); err != nil {
+					clog.ErrorContextf(ctx, "failed to continue process with signal: %v", err)
+				}
+
+				waitFor = -1
+				continue
+			}
+		}
+	}
+}
+
+// Add an event processor function that handles events and completion
+func (t *Tracer) processEvents(ctx context.Context) {
+	defer func() {
+		clog.InfoContext(ctx, "Event processor exiting")
+	}()
+
+	for {
+		select {
+		case <-ctx.Done():
+			clog.InfoContext(ctx, "Context cancelled, stopping event processor")
+			return
+
+		case event, ok := <-t.events:
+			if !ok {
+				clog.InfoContext(ctx, "Event channel closed")
+				return
+			}
+
+			// Process the event
+			clog.DebugContextf(ctx, "Processing event: %s (pid=%d path=%s)",
+				event.SyscallName, event.Pid, event.Path)
+
+			// Handle special event types
+			if event.Type == EventExit {
+				clog.InfoContextf(ctx, "Process exit event: %d", event.Pid)
+
+				// Check if this is the main process
+				if event.Pid == t.cmd.Process.Pid {
+					clog.InfoContext(ctx, "Main process exited")
+					return
+				}
+			}
+		}
+	}
+}
+
+func getStringParam(pid int, addr uint64) (string, error) {
+	// Start with a smaller buffer for efficiency
+	buf := make([]byte, 256)
+	_, err := unix.PtracePeekData(pid, uintptr(addr), buf)
+	if err != nil {
+		return "", fmt.Errorf("error reading string parameter: %w", err)
+	}
+
+	// Find null terminator
+	end := bytes.IndexByte(buf, 0)
+	if end == -1 {
+		// If not found in the small buffer, try a larger one
+		buf = make([]byte, 4096)
+		_, err := unix.PtracePeekData(pid, uintptr(addr), buf)
+		if err != nil {
+			return "", fmt.Errorf("error reading string parameter with larger buffer: %w", err)
+		}
+
+		end = bytes.IndexByte(buf, 0)
+		if end == -1 {
+			// If still not found, this might be an invalid string pointer
+			return "", fmt.Errorf("unable to find null terminator in string at 0x%x", addr)
+		}
+	}
+
+	return string(buf[:end]), nil
+}
+
+// fdName returns a human-readable name for common file descriptors
+func fdName(fd int) string {
+	switch fd {
+	case 0:
+		return "STDIN"
+	case 1:
+		return "STDOUT"
+	case 2:
+		return "STDERR"
+	case AT_FDCWD:
+		return "AT_FDCWD"
+	}
+	return ""
+}
+
+// resolvePath resolves a path based on the process state
+// It handles relative paths, AT_FDCWD, and absolute paths
+func (t *Tracer) resolvePath(pid int, path string, dirfd int) string {
+	// If it's an absolute path, just return it regardless of state
+	if filepath.IsAbs(path) {
+		return filepath.Clean(path)
+	}
+
+	// First check if the process exists before trying to access it
+	_, err := os.Stat(fmt.Sprintf("/proc/%d", pid))
+	if err != nil {
+		if os.IsNotExist(err) {
+			// Process is already gone, just clean the path and return
+			clog.Debugf("Process %d no longer exists when resolving path %s, using best effort", pid, path)
+			return filepath.Clean(path)
+		}
+	}
+
+	// Get state safely
+	t.statesMu.RLock()
+	state, ok := t.states[pid]
+
+	// Make local copies of needed values under lock
+	var cwd, fdPath string
+	var parentPid int
+
+	if ok && state != nil {
+		cwd = state.cwd
+		parentPid = state.parentPid
+
+		// If path is empty and dirfd is valid, try to get fd path
+		if path == "" && dirfd > 0 && state.fdTable != nil {
+			if fd, fdOk := state.fdTable[dirfd]; fdOk {
+				fdPath = fd.Path
+			}
+		} else if dirfd != AT_FDCWD && state.fdTable != nil {
+			// Try to get file descriptor path for non-AT_FDCWD
+			if fd, fdOk := state.fdTable[dirfd]; fdOk {
+				fdPath = fd.Path
+			}
+		}
+	}
+	t.statesMu.RUnlock()
+
+	// If we don't have state for this pid or cwd is empty, try to determine from /proc
+	if !ok || cwd == "" {
+		// Double-check process exists before accessing /proc
+		_, err := os.Stat(fmt.Sprintf("/proc/%d", pid))
+		if err != nil {
+			if os.IsNotExist(err) {
+				// Process is gone, just clean the path and return
+				clog.Debugf("Process %d no longer exists when trying to get cwd, using best effort", pid)
+				return filepath.Clean(path)
+			}
+		}
+
+		procCwd, err := os.Readlink(fmt.Sprintf("/proc/%d/cwd", pid))
+		if err == nil {
+			// Cache in our state for future use
+			if ok {
+				t.statesMu.Lock()
+				if st, exists := t.states[pid]; exists && st != nil {
+					st.cwd = procCwd
+				}
+				t.statesMu.Unlock()
+			}
+
+			// For relative paths, join with cwd
+			if !filepath.IsAbs(path) && path != "" {
+				return filepath.Clean(filepath.Join(procCwd, path))
+			}
+			cwd = procCwd
+		}
+
+		// If no cwd found and path is relative, use current directory as fallback
+		if cwd == "" && !filepath.IsAbs(path) && path != "" {
+			wd, err := os.Getwd()
+			if err == nil {
+				return filepath.Clean(filepath.Join(wd, path))
+			}
+			// Ultimate fallback
+			return filepath.Clean(path)
+		}
+	}
+
+	// Handle empty paths specially, some syscalls use empty path to operate on the dirfd itself
+	if path == "" && dirfd > 0 {
+		if fdPath != "" {
+			return fdPath
+		}
+
+		// Try to resolve from /proc if not in our fd table
+		dirPath, err := os.Readlink(fmt.Sprintf("/proc/%d/fd/%d", pid, dirfd))
+		if err == nil {
+			// Cache for future use
+			t.statesMu.Lock()
+			if st, exists := t.states[pid]; exists && st != nil && st.fdTable != nil {
+				st.fdTable[dirfd] = FD{
+					Path:     dirPath,
+					Type:     "regular",
+					OpenTime: time.Now(),
+				}
+			}
+			t.statesMu.Unlock()
+			return dirPath
+		}
+
+		// Fall back to a placeholder
+		return fmt.Sprintf("<fd:%d>", dirfd)
+	}
+
+	// Special case for AT_FDCWD (-100), use the process's cwd
+	if dirfd == AT_FDCWD || dirfd == 0 {
+		// Use most up-to-date cwd
+		if cwd != "" {
+			return filepath.Clean(filepath.Join(cwd, path))
+		}
+
+		// Check if process still exists
+		_, procErr := os.Stat(fmt.Sprintf("/proc/%d", pid))
+		if procErr != nil && os.IsNotExist(procErr) {
+			// Process is gone, clean the path and return best effort
+			clog.Debugf("Process %d no longer exists when getting cwd, using best effort", pid)
+			return filepath.Clean(path)
+		}
+
+		// Try to get cwd from /proc as a fallback
+		procCwd, err := os.Readlink(fmt.Sprintf("/proc/%d/cwd", pid))
+		if err == nil {
+			// Update our cached cwd
+			t.statesMu.Lock()
+			if st, exists := t.states[pid]; exists && st != nil {
+				st.cwd = procCwd
+			}
+			t.statesMu.Unlock()
+			return filepath.Clean(filepath.Join(procCwd, path))
+		}
+
+		// Ultimate fallback - current process working directory
+		wd, err := os.Getwd()
+		if err == nil {
+			return filepath.Clean(filepath.Join(wd, path))
+		}
+
+		// If everything fails, just clean the path
+		return filepath.Clean(path)
+	}
+
+	// For non-AT_FDCWD cases, check if we have fdPath
+	if fdPath != "" {
+		return filepath.Clean(filepath.Join(fdPath, path))
+	}
+
+	// First check if the process still exists
+	_, procErr := os.Stat(fmt.Sprintf("/proc/%d", pid))
+	if procErr != nil {
+		if os.IsNotExist(procErr) {
+			// Process is gone, just clean the path and return
+			clog.Debugf("Process %d no longer exists when trying to get fd=%d, using best effort", pid, dirfd)
+			return filepath.Clean(path)
+		}
+	}
+
+	// If we don't know the file descriptor, try to read it from /proc
+	dirPath, err := os.Readlink(fmt.Sprintf("/proc/%d/fd/%d", pid, dirfd))
+	if err == nil {
+		// Cache this file descriptor for future use
+		t.statesMu.Lock()
+		if st, exists := t.states[pid]; exists && st != nil && st.fdTable != nil {
+			st.fdTable[dirfd] = FD{
+				Path:     dirPath,
+				Type:     "unknown",
+				OpenTime: time.Now(),
+			}
+		}
+		t.statesMu.Unlock()
+		return filepath.Clean(filepath.Join(dirPath, path))
+	}
+
+	// If we still can't resolve it but have a parent process,
+	// check if the parent has this fd (might be inherited)
+	if parentPid > 0 {
+		var parentFdPath string
+		t.statesMu.RLock()
+		if parentState, ok := t.states[parentPid]; ok && parentState != nil && parentState.fdTable != nil {
+			if parentFd, ok := parentState.fdTable[dirfd]; ok {
+				parentFdPath = parentFd.Path
+			}
+		}
+		t.statesMu.RUnlock()
+
+		if parentFdPath != "" {
+			// Copy to this process's fd table
+			t.statesMu.Lock()
+			if st, exists := t.states[pid]; exists && st != nil && st.fdTable != nil {
+				st.fdTable[dirfd] = FD{
+					Path:     parentFdPath,
+					Type:     "inherited",
+					OpenTime: time.Now(),
+				}
+			}
+			t.statesMu.Unlock()
+			return filepath.Clean(filepath.Join(parentFdPath, path))
+		}
+	}
+
+	// If all else fails, just join with the cwd (best effort)
+	clog.Infof("unable to resolve fd %d for pid %d, falling back to cwd", dirfd, pid)
+	if cwd != "" {
+		return filepath.Clean(filepath.Join(cwd, path))
+	}
+	return filepath.Clean(path)
+}

--- a/tw/testdata/ptrace.txtar
+++ b/tw/testdata/ptrace.txtar
@@ -1,0 +1,21 @@
+ptrace -o json -- crane digest cgr.dev/chainguard/crane:latest
+cmp stdout crane-trace.golden.json
+
+-- crane-trace.golden.json --
+{
+  "args": [
+    "crane",
+    "digest",
+    "cgr.dev/chainguard/crane:latest"
+  ],
+  "files_accessed": {
+    "/etc/hosts": 2,
+    "/etc/nsswitch.conf": 1,
+    "/etc/pki/tls/certs/ca-bundle.crt": 2,
+    "/etc/resolv.conf": 1,
+    "/etc/ssl/certs/ca-bundle.crt": 1,
+    "/etc/ssl/certs/ca-certificates.crt": 2,
+    "/root/.docker/config.json": 1,
+    "/work/containers/auth.json": 1
+  }
+}


### PR DESCRIPTION
adds a naive `ptrace` implementation, most of it is scaffolding for now, but it includes some rudimentary fs ops (mostly `openat`) to produce a list of files read during an execution of some arbitrary command:

```
# go run . ptrace -o json -- curl -s google.com
2025/02/26 01:30:51 INFO tracing command: curl -s google.com
2025/02/26 01:30:51 INFO press ctrl+c to stop tracing
<HTML><HEAD><meta http-equiv="content-type" content="text/html;charset=utf-8">
<TITLE>301 Moved</TITLE></HEAD><BODY>
<H1>301 Moved</H1>
The document has moved
<A HREF="http://www.google.com/">here</A>.
</BODY></HTML>
2025/02/26 01:30:51 INFO main process 89289 is exiting
{
  "args": [
    "curl",
    "-s",
    "google.com"
  ],
  "files_accessed": {
    "/etc/host.conf": 1,
    "/etc/hosts": 1,
    "/etc/ld.so.cache": 3,
    "/etc/ld.so.preload": 1,
    "/etc/nsswitch.conf": 4,
    "/etc/passwd": 1,
    "/etc/resolv.conf": 2,
    "/lib/libc.so.6": 1,
    "/lib/libnss_compat.so.2": 1,
    "/lib/libresolv.so.2": 1,
    "/lib/libz.so.1": 1,
    "/lib64": 1,
    "/usr/lib/libbrotlicommon.so.1": 1,
    "/usr/lib/libbrotlidec.so.1": 1,
    "/usr/lib/libcom_err.so.2": 1,
    "/usr/lib/libcrypto.so.3": 1,
    "/usr/lib/libcurl.so.4": 1,
    "/usr/lib/libevent-2.1.so.7": 1,
    "/usr/lib/libgssapi_krb5.so.2": 1,
    "/usr/lib/libidn2.so.0": 1,
    "/usr/lib/libk5crypto.so.3": 1,
    "/usr/lib/libkeyutils.so.1": 1,
    "/usr/lib/libkrb5.so.3": 1,
    "/usr/lib/libkrb5support.so.0": 1,
    "/usr/lib/liblber.so.2": 1,
    "/usr/lib/libldap.so.2": 1,
    "/usr/lib/libnghttp2.so.14": 1,
    "/usr/lib/libpsl.so.5": 1,
    "/usr/lib/libsasl2.so.3": 1,
    "/usr/lib/libssl.so.3": 1,
    "/usr/lib/libunistring.so.5": 1,
    "/usr/lib/locale/C.utf8/LC_ADDRESS": 1,
    "/usr/lib/locale/C.utf8/LC_CTYPE": 1,
    "/usr/lib/locale/C.utf8/LC_IDENTIFICATION": 1,
    "/usr/lib/locale/C.utf8/LC_MEASUREMENT": 1,
    "/usr/lib/locale/C.utf8/LC_MESSAGES/SYS_LC_MESSAGES": 1,
    "/usr/lib/locale/C.utf8/LC_MONETARY": 1,
    "/usr/lib/locale/C.utf8/LC_NAME": 1,
    "/usr/lib/locale/C.utf8/LC_NUMERIC": 1,
    "/usr/lib/locale/C.utf8/LC_PAPER": 1,
    "/usr/lib/locale/C.utf8/LC_TELEPHONE": 1,
    "/usr/lib/locale/C.utf8/LC_TIME": 1,
    "/usr/lib64": 1,
    "/usr/local/lib": 1,
    "/usr/local/lib64": 1
  }
}
```

this also splits up the existing `tw` binary into its `go build` (`tw`) and `go test -c` counterparts (`twt`). it was getting too complicated and error prone to ship a single test binary that had all the multicall logic, sub command forking, and testscript plumbing logic.

naturally, the new `ptrace` command can be wired into the `twt` testscript approach to do neat snapshot style testing things like:

```
ptrace -o json -- tmux -V
cmp stdout trace.golden.json

-- trace.golden.json --
{
  "args": [
    "tmux",
    "-V"
  ],
  "files_accessed": {
    "/etc/ld.so.cache": 1,
    "/etc/ld.so.preload": 1,
    "/lib/libc.so.6": 1,
    "/lib/libm.so.6": 1,
    "/lib/libresolv.so.2": 1,
    "/usr/lib/libevent_core-2.1.so.7": 1,
    "/usr/lib/libtinfo.so.6": 1,
    "/usr/lib/locale/C.utf8/LC_CTYPE": 1
  }
}
```