### PR TITLE
Build cleanup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ endif
 MELANGE ?= $(shell which melange)
 KEY ?= local-melange.rsa
 REPO ?= $(shell pwd)/packages
+OUT_DIR ?= $(shell pwd)/packages
 
 WOLFI_REPO ?= https://packages.wolfi.dev/os
 WOLFI_KEY ?= https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
@@ -18,6 +19,7 @@ MELANGE_OPTS += --repository-append ${REPO}
 MELANGE_OPTS += -k ${WOLFI_KEY}
 MELANGE_OPTS += -r ${WOLFI_REPO}
 MELANGE_OPTS += --source-dir ./
+MELANGE_OPTS += --out-dir ${OUT_DIR}
 
 MELANGE_BUILD_OPTS += --signing-key ${KEY}
 MELANGE_BUILD_OPTS += --cache-dir $(HOME)/go/pkg/mod
@@ -29,6 +31,9 @@ ${KEY}:
 
 build: $(KEY)
 	$(MELANGE) build melange.yaml $(MELANGE_OPTS) $(MELANGE_BUILD_OPTS)
+
+debug: $(KEY)
+	$(MELANGE) build --interactive melange.yaml $(MELANGE_OPTS) $(MELANGE_BUILD_OPTS)
 
 test: $(KEY)
 	$(MELANGE) test melange.yaml $(MELANGE_OPTS) $(MELANGE_TEST_OPTS)

--- a/melange.yaml
+++ b/melange.yaml
@@ -1,6 +1,6 @@
 package:
   name: tw
-  version: 0.0.0
+  version: 99.0.0
   epoch: 0
   description: Testing tools
   options:
@@ -28,7 +28,7 @@ pipeline:
 
   # Make the tw binary in the main package so we don't end up with `tw-tw`
   - runs: |
-      make -C tw MELANGE_CONTEXTDIR=${{targets.contextdir}} melange-install
+      make -C tw MELANGE_CONTEXTDIR=${{targets.contextdir}} melange-install-tw
 
   - uses: strip
 
@@ -38,7 +38,7 @@ subpackages:
       no-provides: true
     pipeline:
       - runs: |
-          install -Dm755 tw/bin/twt ${{targets.contextdir}}/usr/bin/twt
+          make -C tw MELANGE_CONTEXTDIR=${{targets.contextdir}} melange-install-twt
       - uses: strip
 
   - name: ldd-check

--- a/tw/Makefile
+++ b/tw/Makefile
@@ -1,18 +1,28 @@
 PROJECT = tw
 MELANGE_CONTEXTDIR ?= /tmp/melange-context/$(PROJECT)
-MELANGE_INSTALL_PATH = $(MELANGE_CONTEXTDIR)/usr
+MELANGE_INSTALL_PATH = $(MELANGE_CONTEXTDIR)/usr/bin
 
-.PHONY: build melange-install
+.PHONY: build build-tw build-twt melange-install-tw melange-install-twt
 
-build:
-	mkdir -p bin
-	go build -o bin/tw
-	for cmd in `bin/tw list-multicalls`; do \
-		ln -sf tw bin/$$cmd && echo "Created symlink for $$cmd"; \
+build: build-tw build-twt
+
+build-tw:
+	mkdir -p bin/tw
+	go build -o bin/tw/tw
+	for cmd in `bin/tw/tw list-multicalls`; do \
+		ln -sf tw bin/tw/$$cmd && echo "Created symlink for $$cmd at bin/tw/$$cmd"; \
 	done
-	go test -c -o bin/twt
 
-melange-install: build
+build-twt:
+	mkdir -p bin/twt
+	go test -c -o bin/twt/twt
+
+melange-install-tw: build-tw
 	echo $@
 	mkdir -p $(MELANGE_INSTALL_PATH)
-	cp -r bin $(MELANGE_INSTALL_PATH)
+	cp -r bin/tw/* $(MELANGE_INSTALL_PATH)
+
+melange-install-twt: build-twt
+	echo $@
+	mkdir -p $(MELANGE_INSTALL_PATH)
+	cp -r bin/twt/* $(MELANGE_INSTALL_PATH)

--- a/tw/main.go
+++ b/tw/main.go
@@ -7,11 +7,11 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/chainguard-dev/tw/pkg/commands/assert"
 	"github.com/chainguard-dev/tw/pkg/commands/kgrep"
 	"github.com/chainguard-dev/tw/pkg/commands/kimages"
 	"github.com/chainguard-dev/tw/pkg/commands/sfuzz"
 	"github.com/chainguard-dev/tw/pkg/commands/shu"
-	"github.com/chainguard-dev/tw/pkg/commands/wassert"
 	"github.com/spf13/cobra"
 )
 
@@ -19,7 +19,7 @@ var cmds = map[string]*cobra.Command{
 	"sfuzz":   sfuzz.Command(),
 	"kgrep":   kgrep.Command(),
 	"kimages": kimages.Command(),
-	"wassert": wassert.Command(),
+	"wassert": assert.Command(),
 	"shu":     shu.Command(),
 }
 
@@ -44,20 +44,20 @@ func main() {
 	}
 
 	// Add a helper command for creating the multicall symlinks
-		cmd.AddCommand(
-			&cobra.Command{
-				Use:    "list-multicalls",
-				Hidden: true,
-				Run: func(cmd *cobra.Command, args []string) {
-					names := make([]string, 0)
-					for _, c := range cmds {
-						names = append(names, c.Name())
-					}
-					sort.Strings(names)
-					fmt.Fprint(cmd.OutOrStdout(), strings.Join(names, " "))
-				},
+	cmd.AddCommand(
+		&cobra.Command{
+			Use:    "list-multicalls",
+			Hidden: true,
+			Run: func(cmd *cobra.Command, args []string) {
+				names := make([]string, 0)
+				for _, c := range cmds {
+					names = append(names, c.Name())
+				}
+				sort.Strings(names)
+				fmt.Fprint(cmd.OutOrStdout(), strings.Join(names, " "))
 			},
-		)
+		},
+	)
 
 	if err := cmd.Execute(); err != nil {
 		os.Exit(1)

--- a/tw/main_test.go
+++ b/tw/main_test.go
@@ -10,11 +10,11 @@ import (
 	"testing"
 
 	"github.com/chainguard-dev/clog"
+	"github.com/chainguard-dev/tw/pkg/commands/assert"
 	"github.com/chainguard-dev/tw/pkg/commands/kgrep"
 	"github.com/chainguard-dev/tw/pkg/commands/kimages"
 	"github.com/chainguard-dev/tw/pkg/commands/sfuzz"
 	"github.com/chainguard-dev/tw/pkg/commands/shu"
-	"github.com/chainguard-dev/tw/pkg/commands/wassert"
 	"github.com/rogpeppe/go-internal/testscript"
 	"github.com/spf13/cobra"
 )
@@ -29,7 +29,7 @@ var cmds = map[string]*cobra.Command{
 	"sfuzz":   sfuzz.Command(),
 	"kgrep":   kgrep.Command(),
 	"kimages": kimages.Command(),
-	"wassert": wassert.Command(),
+	"wassert": assert.Command(),
 	"shu":     shu.Command(),
 }
 

--- a/tw/pkg/commands/assert/assert.go
+++ b/tw/pkg/commands/assert/assert.go
@@ -1,4 +1,4 @@
-package wassert
+package assert
 
 import (
 	"strings"
@@ -13,7 +13,8 @@ func Command() *cobra.Command {
 	_ = cfg
 
 	cmd := &cobra.Command{
-		Use: "wassert",
+		Use:   "assert",
+		Short: "Helper cli for making assertions about an environment.",
 	}
 
 	cmd.AddCommand(fileCommand())

--- a/tw/pkg/commands/assert/file.go
+++ b/tw/pkg/commands/assert/file.go
@@ -1,4 +1,4 @@
-package wassert
+package assert
 
 import (
 	"bufio"

--- a/tw/pkg/commands/shu/retry.go
+++ b/tw/pkg/commands/shu/retry.go
@@ -25,8 +25,14 @@ func retryCommand() *cobra.Command {
 	cfg := &retryCfg{}
 
 	cmd := &cobra.Command{
-		Use:     "retry -- <command>",
-		Example: ``,
+		Use: "retry -- <command>",
+		Example: `
+# Retry a command 5 times with a 1s delay between attempts
+shu retry -- echo "Hello, World!"
+
+# Retry a command with a 10s timeout
+shu retry -t 10s -- echo "Hello, World!"
+    `,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return cfg.Run(cmd, args)
 		},

--- a/tw/pkg/commands/shu/shu.go
+++ b/tw/pkg/commands/shu/shu.go
@@ -10,7 +10,8 @@ func Command() *cobra.Command {
 	cfg := &cfg{}
 
 	cmd := &cobra.Command{
-		Use: "shu",
+		Use:   "shu",
+		Short: "A collection of SHell Utilities useful for testing things",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return cfg.Run(cmd, args)
 		},

--- a/tw/pkg/commands/shu/wait.go
+++ b/tw/pkg/commands/shu/wait.go
@@ -27,13 +27,13 @@ func waitCommand() *cobra.Command {
 		Use:   "wait --tcp host:port [--tcp host:port]... [-- command...]",
 		Short: "Wait for services to respond to TCP connections before running a command",
 		Example: `  # Wait for a single service
-  shu wait --tcp localhost:8080
+shu wait --tcp localhost:8080
 
-  # Wait for multiple services
-  shu wait --tcp redis:6379 --tcp postgres:5432
+# Wait for multiple services
+shu wait --tcp redis:6379 --tcp postgres:5432
 
-  # Wait and then run a command
-  shu wait --tcp localhost:8080 -- echo "Service is up!"`,
+# Wait and then run a command
+shu wait --tcp localhost:8080 -- echo "Service is up!"`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return cfg.Run(cmd, args)
 		},

--- a/tw/testdata/sfuzz.txtar
+++ b/tw/testdata/sfuzz.txtar
@@ -1,15 +1,183 @@
-sfuzz --apk go-1.24
+sfuzz --trace -i /work --apk go-1.24
 cmp stdout sfuzz.go-1.24.golden.json
 
-sfuzz --apk ncurses
+sfuzz --trace -i /etc/terminfo --apk ncurses
 cmp stdout sfuzz.ncurses.golden.json
 
 -- sfuzz.go-1.24.golden.json --
 [
   {
     "command": "/usr/bin/go",
+    "exit_code": 2,
+    "flag": "--version",
+    "files_accessed": {
+      "/bin/gccgo": 1,
+      "/go.work": 1,
+      "/sbin/gccgo": 1,
+      "/tmp": 1,
+      "/usr/bin/gccgo": 1,
+      "/usr/lib/go/bin/gcc": 1,
+      "/usr/lib/go/bin/gccgo": 1,
+      "/usr/lib/go/go.env": 1,
+      "/usr/lib/go/pkg/tool": 1,
+      "/usr/local/bin/gcc": 1,
+      "/usr/local/bin/gccgo": 1,
+      "/usr/local/sbin/gcc": 1,
+      "/usr/local/sbin/gccgo": 1,
+      "/usr/sbin/gccgo": 1
+    }
+  },
+  {
+    "command": "/usr/bin/go",
+    "exit_code": 2,
+    "flag": "--help",
+    "files_accessed": {
+      "/bin/gccgo": 1,
+      "/go.work": 1,
+      "/sbin/gccgo": 1,
+      "/tmp": 1,
+      "/usr/bin/gccgo": 1,
+      "/usr/lib/go/bin/gcc": 1,
+      "/usr/lib/go/bin/gccgo": 1,
+      "/usr/lib/go/go.env": 1,
+      "/usr/lib/go/pkg/tool": 1,
+      "/usr/local/bin/gcc": 1,
+      "/usr/local/bin/gccgo": 1,
+      "/usr/local/sbin/gcc": 1,
+      "/usr/local/sbin/gccgo": 1,
+      "/usr/sbin/gccgo": 1
+    }
+  },
+  {
+    "command": "/usr/bin/go",
     "exit_code": 0,
-    "flag": "version"
+    "flag": "version",
+    "files_accessed": {
+      "/bin/gccgo": 1,
+      "/go.work": 2,
+      "/sbin/gccgo": 1,
+      "/tmp": 1,
+      "/usr/bin/gccgo": 1,
+      "/usr/lib/go/bin/gcc": 1,
+      "/usr/lib/go/bin/gccgo": 1,
+      "/usr/lib/go/go.env": 1,
+      "/usr/lib/go/pkg/tool": 1,
+      "/usr/local/bin/gcc": 1,
+      "/usr/local/bin/gccgo": 1,
+      "/usr/local/sbin/gcc": 1,
+      "/usr/local/sbin/gccgo": 1,
+      "/usr/sbin/gccgo": 1
+    }
+  },
+  {
+    "command": "/usr/bin/go",
+    "exit_code": 2,
+    "flag": "-h",
+    "files_accessed": {
+      "/bin/gccgo": 1,
+      "/go.work": 1,
+      "/sbin/gccgo": 1,
+      "/tmp": 1,
+      "/usr/bin/gccgo": 1,
+      "/usr/lib/go/bin/gcc": 1,
+      "/usr/lib/go/bin/gccgo": 1,
+      "/usr/lib/go/go.env": 1,
+      "/usr/lib/go/pkg/tool": 1,
+      "/usr/local/bin/gcc": 1,
+      "/usr/local/bin/gccgo": 1,
+      "/usr/local/sbin/gcc": 1,
+      "/usr/local/sbin/gccgo": 1,
+      "/usr/sbin/gccgo": 1
+    }
+  },
+  {
+    "command": "/usr/bin/go",
+    "exit_code": 2,
+    "flag": "-v",
+    "files_accessed": {
+      "/bin/gccgo": 1,
+      "/go.work": 1,
+      "/sbin/gccgo": 1,
+      "/tmp": 1,
+      "/usr/bin/gccgo": 1,
+      "/usr/lib/go/bin/gcc": 1,
+      "/usr/lib/go/bin/gccgo": 1,
+      "/usr/lib/go/go.env": 1,
+      "/usr/lib/go/pkg/tool": 1,
+      "/usr/local/bin/gcc": 1,
+      "/usr/local/bin/gccgo": 1,
+      "/usr/local/sbin/gcc": 1,
+      "/usr/local/sbin/gccgo": 1,
+      "/usr/sbin/gccgo": 1
+    }
+  },
+  {
+    "command": "/usr/bin/go",
+    "exit_code": 2,
+    "flag": "-version",
+    "files_accessed": {
+      "/bin/gccgo": 1,
+      "/go.work": 1,
+      "/sbin/gccgo": 1,
+      "/tmp": 1,
+      "/usr/bin/gccgo": 1,
+      "/usr/lib/go/bin/gcc": 1,
+      "/usr/lib/go/bin/gccgo": 1,
+      "/usr/lib/go/go.env": 1,
+      "/usr/lib/go/pkg/tool": 1,
+      "/usr/local/bin/gcc": 1,
+      "/usr/local/bin/gccgo": 1,
+      "/usr/local/sbin/gcc": 1,
+      "/usr/local/sbin/gccgo": 1,
+      "/usr/sbin/gccgo": 1
+    }
+  },
+  {
+    "command": "/usr/bin/go",
+    "exit_code": 2,
+    "flag": "-help",
+    "files_accessed": {
+      "/bin/gccgo": 1,
+      "/go.work": 1,
+      "/sbin/gccgo": 1,
+      "/tmp": 1,
+      "/usr/bin/gccgo": 1,
+      "/usr/lib/go/bin/gcc": 1,
+      "/usr/lib/go/bin/gccgo": 1,
+      "/usr/lib/go/go.env": 1,
+      "/usr/lib/go/pkg/tool": 1,
+      "/usr/local/bin/gcc": 1,
+      "/usr/local/bin/gccgo": 1,
+      "/usr/local/sbin/gcc": 1,
+      "/usr/local/sbin/gccgo": 1,
+      "/usr/sbin/gccgo": 1
+    }
+  },
+  {
+    "command": "/usr/bin/go",
+    "exit_code": 2,
+    "flag": "-V",
+    "files_accessed": {
+      "/bin/gccgo": 1,
+      "/go.work": 1,
+      "/sbin/gccgo": 1,
+      "/tmp": 1,
+      "/usr/bin/gccgo": 1,
+      "/usr/lib/go/bin/gcc": 1,
+      "/usr/lib/go/bin/gccgo": 1,
+      "/usr/lib/go/go.env": 1,
+      "/usr/lib/go/pkg/tool": 1,
+      "/usr/local/bin/gcc": 1,
+      "/usr/local/bin/gccgo": 1,
+      "/usr/local/sbin/gcc": 1,
+      "/usr/local/sbin/gccgo": 1,
+      "/usr/sbin/gccgo": 1
+    }
+  },
+  {
+    "command": "/usr/bin/gofmt",
+    "exit_code": 2,
+    "flag": "--version"
   },
   {
     "command": "/usr/bin/gofmt",
@@ -18,13 +186,33 @@ cmp stdout sfuzz.ncurses.golden.json
   },
   {
     "command": "/usr/bin/gofmt",
+    "exit_code": 2,
+    "flag": "version"
+  },
+  {
+    "command": "/usr/bin/gofmt",
     "exit_code": 0,
     "flag": "-h"
   },
   {
     "command": "/usr/bin/gofmt",
+    "exit_code": 2,
+    "flag": "-v"
+  },
+  {
+    "command": "/usr/bin/gofmt",
+    "exit_code": 2,
+    "flag": "-version"
+  },
+  {
+    "command": "/usr/bin/gofmt",
     "exit_code": 0,
     "flag": "-help"
+  },
+  {
+    "command": "/usr/bin/gofmt",
+    "exit_code": 2,
+    "flag": "-V"
   }
 ]
 -- sfuzz.ncurses.golden.json --
@@ -32,66 +220,955 @@ cmp stdout sfuzz.ncurses.golden.json
   {
     "command": "/usr/bin/captoinfo",
     "exit_code": 0,
-    "flag": "-V"
+    "flag": "--version",
+    "files_accessed": {
+      "/etc/ld.so.cache": 1,
+      "/etc/ld.so.preload": 1,
+      "/lib/libc.so.6": 1,
+      "/usr/lib/libncursesw.so.6": 1,
+      "/usr/lib/libtinfo.so.6": 1
+    }
+  },
+  {
+    "command": "/usr/bin/captoinfo",
+    "exit_code": 0,
+    "flag": "--help",
+    "files_accessed": {
+      "/etc/ld.so.cache": 1,
+      "/etc/ld.so.preload": 1,
+      "/lib/libc.so.6": 1,
+      "/usr/lib/libncursesw.so.6": 1,
+      "/usr/lib/libtinfo.so.6": 1
+    }
+  },
+  {
+    "command": "/usr/bin/captoinfo",
+    "exit_code": 0,
+    "flag": "version",
+    "files_accessed": {
+      "/etc/ld.so.cache": 1,
+      "/etc/ld.so.preload": 1,
+      "/lib/libc.so.6": 1,
+      "/usr/lib/libncursesw.so.6": 1,
+      "/usr/lib/libtinfo.so.6": 1
+    }
+  },
+  {
+    "command": "/usr/bin/captoinfo",
+    "exit_code": 0,
+    "flag": "-h",
+    "files_accessed": {
+      "/etc/ld.so.cache": 1,
+      "/etc/ld.so.preload": 1,
+      "/lib/libc.so.6": 1,
+      "/usr/lib/libncursesw.so.6": 1,
+      "/usr/lib/libtinfo.so.6": 1
+    }
+  },
+  {
+    "command": "/usr/bin/captoinfo",
+    "exit_code": 0,
+    "flag": "-v",
+    "files_accessed": {
+      "/etc/ld.so.cache": 1,
+      "/etc/ld.so.preload": 1,
+      "/etc/termcap": 1,
+      "/lib/libc.so.6": 1,
+      "/usr/lib/libncursesw.so.6": 1,
+      "/usr/lib/libtinfo.so.6": 1
+    }
+  },
+  {
+    "command": "/usr/bin/captoinfo",
+    "exit_code": 0,
+    "flag": "-version",
+    "files_accessed": {
+      "/etc/ld.so.cache": 1,
+      "/etc/ld.so.preload": 1,
+      "/etc/termcap": 1,
+      "/lib/libc.so.6": 1,
+      "/usr/lib/libncursesw.so.6": 1,
+      "/usr/lib/libtinfo.so.6": 1
+    }
+  },
+  {
+    "command": "/usr/bin/captoinfo",
+    "exit_code": 0,
+    "flag": "-help",
+    "files_accessed": {
+      "/etc/ld.so.cache": 1,
+      "/etc/ld.so.preload": 1,
+      "/lib/libc.so.6": 1,
+      "/usr/lib/libncursesw.so.6": 1,
+      "/usr/lib/libtinfo.so.6": 1
+    }
+  },
+  {
+    "command": "/usr/bin/captoinfo",
+    "exit_code": 0,
+    "flag": "-V",
+    "files_accessed": {
+      "/etc/ld.so.cache": 1,
+      "/etc/ld.so.preload": 1,
+      "/lib/libc.so.6": 1,
+      "/usr/lib/libncursesw.so.6": 1,
+      "/usr/lib/libtinfo.so.6": 1
+    }
   },
   {
     "command": "/usr/bin/clear",
     "exit_code": 0,
-    "flag": "-V"
+    "flag": "--version",
+    "files_accessed": {
+      "/etc/ld.so.cache": 1,
+      "/etc/ld.so.preload": 1,
+      "/lib/libc.so.6": 1,
+      "/usr/lib/libtinfo.so.6": 1
+    }
+  },
+  {
+    "command": "/usr/bin/clear",
+    "exit_code": 0,
+    "flag": "--help",
+    "files_accessed": {
+      "/etc/ld.so.cache": 1,
+      "/etc/ld.so.preload": 1,
+      "/lib/libc.so.6": 1,
+      "/usr/lib/libtinfo.so.6": 1
+    }
+  },
+  {
+    "command": "/usr/bin/clear",
+    "exit_code": 0,
+    "flag": "version",
+    "files_accessed": {
+      "/etc/ld.so.cache": 1,
+      "/etc/ld.so.preload": 1,
+      "/lib/libc.so.6": 1,
+      "/usr/lib/libtinfo.so.6": 1
+    }
+  },
+  {
+    "command": "/usr/bin/clear",
+    "exit_code": 0,
+    "flag": "-h",
+    "files_accessed": {
+      "/etc/ld.so.cache": 1,
+      "/etc/ld.so.preload": 1,
+      "/lib/libc.so.6": 1,
+      "/usr/lib/libtinfo.so.6": 1
+    }
+  },
+  {
+    "command": "/usr/bin/clear",
+    "exit_code": 0,
+    "flag": "-v",
+    "files_accessed": {
+      "/etc/ld.so.cache": 1,
+      "/etc/ld.so.preload": 1,
+      "/lib/libc.so.6": 1,
+      "/usr/lib/libtinfo.so.6": 1
+    }
+  },
+  {
+    "command": "/usr/bin/clear",
+    "exit_code": 0,
+    "flag": "-version",
+    "files_accessed": {
+      "/etc/ld.so.cache": 1,
+      "/etc/ld.so.preload": 1,
+      "/lib/libc.so.6": 1,
+      "/usr/lib/libtinfo.so.6": 1
+    }
+  },
+  {
+    "command": "/usr/bin/clear",
+    "exit_code": 0,
+    "flag": "-help",
+    "files_accessed": {
+      "/etc/ld.so.cache": 1,
+      "/etc/ld.so.preload": 1,
+      "/lib/libc.so.6": 1,
+      "/usr/lib/libtinfo.so.6": 1
+    }
+  },
+  {
+    "command": "/usr/bin/clear",
+    "exit_code": 0,
+    "flag": "-V",
+    "files_accessed": {
+      "/etc/ld.so.cache": 1,
+      "/etc/ld.so.preload": 1,
+      "/lib/libc.so.6": 1,
+      "/usr/lib/libtinfo.so.6": 1
+    }
   },
   {
     "command": "/usr/bin/infocmp",
     "exit_code": 0,
-    "flag": "-V"
+    "flag": "--version",
+    "files_accessed": {
+      "/etc/ld.so.cache": 1,
+      "/etc/ld.so.preload": 1,
+      "/lib/libc.so.6": 1,
+      "/usr/lib/libncursesw.so.6": 1,
+      "/usr/lib/libtinfo.so.6": 1
+    }
+  },
+  {
+    "command": "/usr/bin/infocmp",
+    "exit_code": 0,
+    "flag": "--help",
+    "files_accessed": {
+      "/etc/ld.so.cache": 1,
+      "/etc/ld.so.preload": 1,
+      "/lib/libc.so.6": 1,
+      "/usr/lib/libncursesw.so.6": 1,
+      "/usr/lib/libtinfo.so.6": 1
+    }
+  },
+  {
+    "command": "/usr/bin/infocmp",
+    "exit_code": 0,
+    "flag": "version",
+    "files_accessed": {
+      "/etc/ld.so.cache": 1,
+      "/etc/ld.so.preload": 1,
+      "/lib/libc.so.6": 1,
+      "/lib/terminfo": 1,
+      "/root/.terminfo": 1,
+      "/usr/lib/libncursesw.so.6": 1,
+      "/usr/lib/libtinfo.so.6": 1,
+      "/usr/lib/terminfo": 1,
+      "/usr/share/terminfo": 1
+    }
+  },
+  {
+    "command": "/usr/bin/infocmp",
+    "exit_code": 0,
+    "flag": "-h",
+    "files_accessed": {
+      "/etc/ld.so.cache": 1,
+      "/etc/ld.so.preload": 1,
+      "/lib/libc.so.6": 1,
+      "/usr/lib/libncursesw.so.6": 1,
+      "/usr/lib/libtinfo.so.6": 1
+    }
+  },
+  {
+    "command": "/usr/bin/infocmp",
+    "exit_code": 0,
+    "flag": "-v",
+    "files_accessed": {
+      "/etc/ld.so.cache": 1,
+      "/etc/ld.so.preload": 1,
+      "/lib/libc.so.6": 1,
+      "/usr/lib/libncursesw.so.6": 1,
+      "/usr/lib/libtinfo.so.6": 1
+    }
+  },
+  {
+    "command": "/usr/bin/infocmp",
+    "exit_code": 0,
+    "flag": "-version",
+    "files_accessed": {
+      "/etc/ld.so.cache": 1,
+      "/etc/ld.so.preload": 1,
+      "/lib/libc.so.6": 1,
+      "/usr/lib/libncursesw.so.6": 1,
+      "/usr/lib/libtinfo.so.6": 1
+    }
+  },
+  {
+    "command": "/usr/bin/infocmp",
+    "exit_code": 0,
+    "flag": "-help",
+    "files_accessed": {
+      "/etc/ld.so.cache": 1,
+      "/etc/ld.so.preload": 1,
+      "/lib/libc.so.6": 1,
+      "/usr/lib/libncursesw.so.6": 1,
+      "/usr/lib/libtinfo.so.6": 1
+    }
+  },
+  {
+    "command": "/usr/bin/infocmp",
+    "exit_code": 0,
+    "flag": "-V",
+    "files_accessed": {
+      "/etc/ld.so.cache": 1,
+      "/etc/ld.so.preload": 1,
+      "/lib/libc.so.6": 1,
+      "/usr/lib/libncursesw.so.6": 1,
+      "/usr/lib/libtinfo.so.6": 1
+    }
   },
   {
     "command": "/usr/bin/infotocap",
     "exit_code": 0,
-    "flag": "-V"
+    "flag": "--version",
+    "files_accessed": {
+      "/etc/ld.so.cache": 1,
+      "/etc/ld.so.preload": 1,
+      "/lib/libc.so.6": 1,
+      "/usr/lib/libncursesw.so.6": 1,
+      "/usr/lib/libtinfo.so.6": 1
+    }
+  },
+  {
+    "command": "/usr/bin/infotocap",
+    "exit_code": 0,
+    "flag": "--help",
+    "files_accessed": {
+      "/etc/ld.so.cache": 1,
+      "/etc/ld.so.preload": 1,
+      "/lib/libc.so.6": 1,
+      "/usr/lib/libncursesw.so.6": 1,
+      "/usr/lib/libtinfo.so.6": 1
+    }
+  },
+  {
+    "command": "/usr/bin/infotocap",
+    "exit_code": 0,
+    "flag": "version",
+    "files_accessed": {
+      "/etc/ld.so.cache": 1,
+      "/etc/ld.so.preload": 1,
+      "/lib/libc.so.6": 1,
+      "/usr/lib/libncursesw.so.6": 1,
+      "/usr/lib/libtinfo.so.6": 1
+    }
+  },
+  {
+    "command": "/usr/bin/infotocap",
+    "exit_code": 0,
+    "flag": "-h",
+    "files_accessed": {
+      "/etc/ld.so.cache": 1,
+      "/etc/ld.so.preload": 1,
+      "/lib/libc.so.6": 1,
+      "/usr/lib/libncursesw.so.6": 1,
+      "/usr/lib/libtinfo.so.6": 1
+    }
+  },
+  {
+    "command": "/usr/bin/infotocap",
+    "exit_code": 0,
+    "flag": "-v",
+    "files_accessed": {
+      "/etc/ld.so.cache": 1,
+      "/etc/ld.so.preload": 1,
+      "/lib/libc.so.6": 1,
+      "/usr/lib/libncursesw.so.6": 1,
+      "/usr/lib/libtinfo.so.6": 1
+    }
+  },
+  {
+    "command": "/usr/bin/infotocap",
+    "exit_code": 0,
+    "flag": "-version",
+    "files_accessed": {
+      "/etc/ld.so.cache": 1,
+      "/etc/ld.so.preload": 1,
+      "/lib/libc.so.6": 1,
+      "/usr/lib/libncursesw.so.6": 1,
+      "/usr/lib/libtinfo.so.6": 1
+    }
+  },
+  {
+    "command": "/usr/bin/infotocap",
+    "exit_code": 0,
+    "flag": "-help",
+    "files_accessed": {
+      "/etc/ld.so.cache": 1,
+      "/etc/ld.so.preload": 1,
+      "/lib/libc.so.6": 1,
+      "/usr/lib/libncursesw.so.6": 1,
+      "/usr/lib/libtinfo.so.6": 1
+    }
+  },
+  {
+    "command": "/usr/bin/infotocap",
+    "exit_code": 0,
+    "flag": "-V",
+    "files_accessed": {
+      "/etc/ld.so.cache": 1,
+      "/etc/ld.so.preload": 1,
+      "/lib/libc.so.6": 1,
+      "/usr/lib/libncursesw.so.6": 1,
+      "/usr/lib/libtinfo.so.6": 1
+    }
   },
   {
     "command": "/usr/bin/reset",
     "exit_code": 0,
-    "flag": "-V"
+    "flag": "--version",
+    "files_accessed": {
+      "/etc/ld.so.cache": 1,
+      "/etc/ld.so.preload": 1,
+      "/lib/libc.so.6": 1,
+      "/usr/lib/libtinfo.so.6": 1
+    }
+  },
+  {
+    "command": "/usr/bin/reset",
+    "exit_code": 0,
+    "flag": "--help",
+    "files_accessed": {
+      "/etc/ld.so.cache": 1,
+      "/etc/ld.so.preload": 1,
+      "/lib/libc.so.6": 1,
+      "/usr/lib/libtinfo.so.6": 1
+    }
+  },
+  {
+    "command": "/usr/bin/reset",
+    "exit_code": 0,
+    "flag": "version",
+    "files_accessed": {
+      "/etc/ld.so.cache": 1,
+      "/etc/ld.so.preload": 1,
+      "/lib/libc.so.6": 1,
+      "/lib/terminfo": 1,
+      "/root/.terminfo": 1,
+      "/usr/lib/libtinfo.so.6": 1,
+      "/usr/lib/terminfo": 1,
+      "/usr/share/terminfo": 1
+    }
+  },
+  {
+    "command": "/usr/bin/reset",
+    "exit_code": 0,
+    "flag": "-h",
+    "files_accessed": {
+      "/etc/ld.so.cache": 1,
+      "/etc/ld.so.preload": 1,
+      "/lib/libc.so.6": 1,
+      "/usr/lib/libtinfo.so.6": 1
+    }
+  },
+  {
+    "command": "/usr/bin/reset",
+    "exit_code": 0,
+    "flag": "-v",
+    "files_accessed": {
+      "/etc/ld.so.cache": 1,
+      "/etc/ld.so.preload": 1,
+      "/lib/libc.so.6": 1,
+      "/usr/lib/libtinfo.so.6": 1
+    }
+  },
+  {
+    "command": "/usr/bin/reset",
+    "exit_code": 0,
+    "flag": "-version",
+    "files_accessed": {
+      "/etc/ld.so.cache": 1,
+      "/etc/ld.so.preload": 1,
+      "/lib/libc.so.6": 1,
+      "/usr/lib/libtinfo.so.6": 1
+    }
+  },
+  {
+    "command": "/usr/bin/reset",
+    "exit_code": 0,
+    "flag": "-help",
+    "files_accessed": {
+      "/etc/ld.so.cache": 1,
+      "/etc/ld.so.preload": 1,
+      "/lib/libc.so.6": 1,
+      "/usr/lib/libtinfo.so.6": 1
+    }
+  },
+  {
+    "command": "/usr/bin/reset",
+    "exit_code": 0,
+    "flag": "-V",
+    "files_accessed": {
+      "/etc/ld.so.cache": 1,
+      "/etc/ld.so.preload": 1,
+      "/lib/libc.so.6": 1,
+      "/usr/lib/libtinfo.so.6": 1
+    }
   },
   {
     "command": "/usr/bin/tabs",
     "exit_code": 0,
-    "flag": "-V"
+    "flag": "--version",
+    "files_accessed": {
+      "/etc/ld.so.cache": 1,
+      "/etc/ld.so.preload": 1,
+      "/lib/libc.so.6": 1,
+      "/usr/lib/libtinfo.so.6": 1
+    }
+  },
+  {
+    "command": "/usr/bin/tabs",
+    "exit_code": 0,
+    "flag": "--help",
+    "files_accessed": {
+      "/etc/ld.so.cache": 1,
+      "/etc/ld.so.preload": 1,
+      "/lib/libc.so.6": 1,
+      "/usr/lib/libtinfo.so.6": 1
+    }
+  },
+  {
+    "command": "/usr/bin/tabs",
+    "exit_code": 0,
+    "flag": "version",
+    "files_accessed": {
+      "/etc/ld.so.cache": 1,
+      "/etc/ld.so.preload": 1,
+      "/lib/libc.so.6": 1,
+      "/lib/terminfo": 1,
+      "/root/.terminfo": 1,
+      "/usr/lib/libtinfo.so.6": 1,
+      "/usr/lib/terminfo": 1,
+      "/usr/share/terminfo": 1
+    }
+  },
+  {
+    "command": "/usr/bin/tabs",
+    "exit_code": 0,
+    "flag": "-h",
+    "files_accessed": {
+      "/etc/ld.so.cache": 1,
+      "/etc/ld.so.preload": 1,
+      "/lib/libc.so.6": 1,
+      "/usr/lib/libtinfo.so.6": 1
+    }
+  },
+  {
+    "command": "/usr/bin/tabs",
+    "exit_code": 0,
+    "flag": "-v",
+    "files_accessed": {
+      "/etc/ld.so.cache": 1,
+      "/etc/ld.so.preload": 1,
+      "/lib/libc.so.6": 1,
+      "/usr/lib/libtinfo.so.6": 1
+    }
+  },
+  {
+    "command": "/usr/bin/tabs",
+    "exit_code": 0,
+    "flag": "-version",
+    "files_accessed": {
+      "/etc/ld.so.cache": 1,
+      "/etc/ld.so.preload": 1,
+      "/lib/libc.so.6": 1,
+      "/usr/lib/libtinfo.so.6": 1
+    }
+  },
+  {
+    "command": "/usr/bin/tabs",
+    "exit_code": 0,
+    "flag": "-help",
+    "files_accessed": {
+      "/etc/ld.so.cache": 1,
+      "/etc/ld.so.preload": 1,
+      "/lib/libc.so.6": 1,
+      "/usr/lib/libtinfo.so.6": 1
+    }
+  },
+  {
+    "command": "/usr/bin/tabs",
+    "exit_code": 0,
+    "flag": "-V",
+    "files_accessed": {
+      "/etc/ld.so.cache": 1,
+      "/etc/ld.so.preload": 1,
+      "/lib/libc.so.6": 1,
+      "/usr/lib/libtinfo.so.6": 1
+    }
   },
   {
     "command": "/usr/bin/tic",
     "exit_code": 0,
-    "flag": "-V"
+    "flag": "--version",
+    "files_accessed": {
+      "/etc/ld.so.cache": 1,
+      "/etc/ld.so.preload": 1,
+      "/lib/libc.so.6": 1,
+      "/usr/lib/libncursesw.so.6": 1,
+      "/usr/lib/libtinfo.so.6": 1
+    }
+  },
+  {
+    "command": "/usr/bin/tic",
+    "exit_code": 0,
+    "flag": "--help",
+    "files_accessed": {
+      "/etc/ld.so.cache": 1,
+      "/etc/ld.so.preload": 1,
+      "/lib/libc.so.6": 1,
+      "/usr/lib/libncursesw.so.6": 1,
+      "/usr/lib/libtinfo.so.6": 1
+    }
+  },
+  {
+    "command": "/usr/bin/tic",
+    "exit_code": 0,
+    "flag": "version",
+    "files_accessed": {
+      "/etc/ld.so.cache": 1,
+      "/etc/ld.so.preload": 1,
+      "/lib/libc.so.6": 1,
+      "/usr/lib/libncursesw.so.6": 1,
+      "/usr/lib/libtinfo.so.6": 1
+    }
+  },
+  {
+    "command": "/usr/bin/tic",
+    "exit_code": 0,
+    "flag": "-h",
+    "files_accessed": {
+      "/etc/ld.so.cache": 1,
+      "/etc/ld.so.preload": 1,
+      "/lib/libc.so.6": 1,
+      "/usr/lib/libncursesw.so.6": 1,
+      "/usr/lib/libtinfo.so.6": 1
+    }
+  },
+  {
+    "command": "/usr/bin/tic",
+    "exit_code": 0,
+    "flag": "-v",
+    "files_accessed": {
+      "/etc/ld.so.cache": 1,
+      "/etc/ld.so.preload": 1,
+      "/lib/libc.so.6": 1,
+      "/usr/lib/libncursesw.so.6": 1,
+      "/usr/lib/libtinfo.so.6": 1
+    }
+  },
+  {
+    "command": "/usr/bin/tic",
+    "exit_code": 0,
+    "flag": "-version",
+    "files_accessed": {
+      "/etc/ld.so.cache": 1,
+      "/etc/ld.so.preload": 1,
+      "/lib/libc.so.6": 1,
+      "/usr/lib/libncursesw.so.6": 1,
+      "/usr/lib/libtinfo.so.6": 1
+    }
+  },
+  {
+    "command": "/usr/bin/tic",
+    "exit_code": 0,
+    "flag": "-help",
+    "files_accessed": {
+      "/etc/ld.so.cache": 1,
+      "/etc/ld.so.preload": 1,
+      "/lib/libc.so.6": 1,
+      "/usr/lib/libncursesw.so.6": 1,
+      "/usr/lib/libtinfo.so.6": 1
+    }
+  },
+  {
+    "command": "/usr/bin/tic",
+    "exit_code": 0,
+    "flag": "-V",
+    "files_accessed": {
+      "/etc/ld.so.cache": 1,
+      "/etc/ld.so.preload": 1,
+      "/lib/libc.so.6": 1,
+      "/usr/lib/libncursesw.so.6": 1,
+      "/usr/lib/libtinfo.so.6": 1
+    }
   },
   {
     "command": "/usr/bin/toe",
     "exit_code": 0,
-    "flag": "version"
+    "flag": "--version",
+    "files_accessed": {
+      "/etc/ld.so.cache": 1,
+      "/etc/ld.so.preload": 1,
+      "/lib/libc.so.6": 1,
+      "/usr/lib/libncursesw.so.6": 1,
+      "/usr/lib/libtinfo.so.6": 1
+    }
   },
   {
     "command": "/usr/bin/toe",
     "exit_code": 0,
-    "flag": "-h"
+    "flag": "--help",
+    "files_accessed": {
+      "/etc/ld.so.cache": 1,
+      "/etc/ld.so.preload": 1,
+      "/lib/libc.so.6": 1,
+      "/usr/lib/libncursesw.so.6": 1,
+      "/usr/lib/libtinfo.so.6": 1
+    }
   },
   {
     "command": "/usr/bin/toe",
     "exit_code": 0,
-    "flag": "-v"
+    "flag": "version",
+    "files_accessed": {
+      "/etc/ld.so.cache": 1,
+      "/etc/ld.so.preload": 1,
+      "/lib/libc.so.6": 1,
+      "/usr/lib/libncursesw.so.6": 1,
+      "/usr/lib/libtinfo.so.6": 1
+    }
   },
   {
     "command": "/usr/bin/toe",
     "exit_code": 0,
-    "flag": "-V"
+    "flag": "-h",
+    "files_accessed": {
+      "/etc/ld.so.cache": 1,
+      "/etc/ld.so.preload": 1,
+      "/lib/libc.so.6": 1,
+      "/lib/terminfo": 1,
+      "/root/.terminfo": 1,
+      "/usr/lib/libncursesw.so.6": 1,
+      "/usr/lib/libtinfo.so.6": 1,
+      "/usr/lib/terminfo": 1,
+      "/usr/share/terminfo": 1
+    }
+  },
+  {
+    "command": "/usr/bin/toe",
+    "exit_code": 0,
+    "flag": "-v",
+    "files_accessed": {
+      "/etc/ld.so.cache": 1,
+      "/etc/ld.so.preload": 1,
+      "/lib/libc.so.6": 1,
+      "/lib/terminfo": 1,
+      "/root/.terminfo": 1,
+      "/usr/lib/libncursesw.so.6": 1,
+      "/usr/lib/libtinfo.so.6": 1,
+      "/usr/lib/terminfo": 1,
+      "/usr/share/terminfo": 1
+    }
+  },
+  {
+    "command": "/usr/bin/toe",
+    "exit_code": 0,
+    "flag": "-version",
+    "files_accessed": {
+      "/etc/ld.so.cache": 1,
+      "/etc/ld.so.preload": 1,
+      "/lib/libc.so.6": 1,
+      "/usr/lib/libncursesw.so.6": 1,
+      "/usr/lib/libtinfo.so.6": 1
+    }
+  },
+  {
+    "command": "/usr/bin/toe",
+    "exit_code": 0,
+    "flag": "-help",
+    "files_accessed": {
+      "/etc/ld.so.cache": 1,
+      "/etc/ld.so.preload": 1,
+      "/lib/libc.so.6": 1,
+      "/usr/lib/libncursesw.so.6": 1,
+      "/usr/lib/libtinfo.so.6": 1
+    }
+  },
+  {
+    "command": "/usr/bin/toe",
+    "exit_code": 0,
+    "flag": "-V",
+    "files_accessed": {
+      "/etc/ld.so.cache": 1,
+      "/etc/ld.so.preload": 1,
+      "/lib/libc.so.6": 1,
+      "/usr/lib/libncursesw.so.6": 1,
+      "/usr/lib/libtinfo.so.6": 1
+    }
   },
   {
     "command": "/usr/bin/tput",
     "exit_code": 0,
-    "flag": "-V"
+    "flag": "--version",
+    "files_accessed": {
+      "/etc/ld.so.cache": 1,
+      "/etc/ld.so.preload": 1,
+      "/lib/libc.so.6": 1,
+      "/usr/lib/libtinfo.so.6": 1
+    }
+  },
+  {
+    "command": "/usr/bin/tput",
+    "exit_code": 0,
+    "flag": "--help",
+    "files_accessed": {
+      "/etc/ld.so.cache": 1,
+      "/etc/ld.so.preload": 1,
+      "/lib/libc.so.6": 1,
+      "/usr/lib/libtinfo.so.6": 1
+    }
+  },
+  {
+    "command": "/usr/bin/tput",
+    "exit_code": 0,
+    "flag": "version",
+    "files_accessed": {
+      "/etc/ld.so.cache": 1,
+      "/etc/ld.so.preload": 1,
+      "/lib/libc.so.6": 1,
+      "/lib/terminfo": 1,
+      "/root/.terminfo": 1,
+      "/usr/lib/libtinfo.so.6": 1,
+      "/usr/lib/terminfo": 1,
+      "/usr/share/terminfo": 1
+    }
+  },
+  {
+    "command": "/usr/bin/tput",
+    "exit_code": 0,
+    "flag": "-h",
+    "files_accessed": {
+      "/etc/ld.so.cache": 1,
+      "/etc/ld.so.preload": 1,
+      "/lib/libc.so.6": 1,
+      "/usr/lib/libtinfo.so.6": 1
+    }
+  },
+  {
+    "command": "/usr/bin/tput",
+    "exit_code": 0,
+    "flag": "-v",
+    "files_accessed": {
+      "/etc/ld.so.cache": 1,
+      "/etc/ld.so.preload": 1,
+      "/lib/libc.so.6": 1,
+      "/lib/terminfo": 1,
+      "/root/.terminfo": 1,
+      "/usr/lib/libtinfo.so.6": 1,
+      "/usr/lib/terminfo": 1,
+      "/usr/share/terminfo": 1
+    }
+  },
+  {
+    "command": "/usr/bin/tput",
+    "exit_code": 0,
+    "flag": "-version",
+    "files_accessed": {
+      "/etc/ld.so.cache": 1,
+      "/etc/ld.so.preload": 1,
+      "/lib/libc.so.6": 1,
+      "/usr/lib/libtinfo.so.6": 1
+    }
+  },
+  {
+    "command": "/usr/bin/tput",
+    "exit_code": 0,
+    "flag": "-help",
+    "files_accessed": {
+      "/etc/ld.so.cache": 1,
+      "/etc/ld.so.preload": 1,
+      "/lib/libc.so.6": 1,
+      "/usr/lib/libtinfo.so.6": 1
+    }
+  },
+  {
+    "command": "/usr/bin/tput",
+    "exit_code": 0,
+    "flag": "-V",
+    "files_accessed": {
+      "/etc/ld.so.cache": 1,
+      "/etc/ld.so.preload": 1,
+      "/lib/libc.so.6": 1,
+      "/usr/lib/libtinfo.so.6": 1
+    }
   },
   {
     "command": "/usr/bin/tset",
     "exit_code": 0,
-    "flag": "-V"
+    "flag": "--version",
+    "files_accessed": {
+      "/etc/ld.so.cache": 1,
+      "/etc/ld.so.preload": 1,
+      "/lib/libc.so.6": 1,
+      "/usr/lib/libtinfo.so.6": 1
+    }
+  },
+  {
+    "command": "/usr/bin/tset",
+    "exit_code": 0,
+    "flag": "--help",
+    "files_accessed": {
+      "/etc/ld.so.cache": 1,
+      "/etc/ld.so.preload": 1,
+      "/lib/libc.so.6": 1,
+      "/usr/lib/libtinfo.so.6": 1
+    }
+  },
+  {
+    "command": "/usr/bin/tset",
+    "exit_code": 0,
+    "flag": "version",
+    "files_accessed": {
+      "/etc/ld.so.cache": 1,
+      "/etc/ld.so.preload": 1,
+      "/lib/libc.so.6": 1,
+      "/lib/terminfo": 1,
+      "/root/.terminfo": 1,
+      "/usr/lib/libtinfo.so.6": 1,
+      "/usr/lib/terminfo": 1,
+      "/usr/share/terminfo": 1
+    }
+  },
+  {
+    "command": "/usr/bin/tset",
+    "exit_code": 0,
+    "flag": "-h",
+    "files_accessed": {
+      "/etc/ld.so.cache": 1,
+      "/etc/ld.so.preload": 1,
+      "/lib/libc.so.6": 1,
+      "/usr/lib/libtinfo.so.6": 1
+    }
+  },
+  {
+    "command": "/usr/bin/tset",
+    "exit_code": 0,
+    "flag": "-v",
+    "files_accessed": {
+      "/etc/ld.so.cache": 1,
+      "/etc/ld.so.preload": 1,
+      "/lib/libc.so.6": 1,
+      "/usr/lib/libtinfo.so.6": 1
+    }
+  },
+  {
+    "command": "/usr/bin/tset",
+    "exit_code": 0,
+    "flag": "-version",
+    "files_accessed": {
+      "/etc/ld.so.cache": 1,
+      "/etc/ld.so.preload": 1,
+      "/lib/libc.so.6": 1,
+      "/usr/lib/libtinfo.so.6": 1
+    }
+  },
+  {
+    "command": "/usr/bin/tset",
+    "exit_code": 0,
+    "flag": "-help",
+    "files_accessed": {
+      "/etc/ld.so.cache": 1,
+      "/etc/ld.so.preload": 1,
+      "/lib/libc.so.6": 1,
+      "/usr/lib/libtinfo.so.6": 1
+    }
+  },
+  {
+    "command": "/usr/bin/tset",
+    "exit_code": 0,
+    "flag": "-V",
+    "files_accessed": {
+      "/etc/ld.so.cache": 1,
+      "/etc/ld.so.preload": 1,
+      "/lib/libc.so.6": 1,
+      "/usr/lib/libtinfo.so.6": 1
+    }
   }
 ]


### PR DESCRIPTION
split the `tw` and `twt` binary into two to simplify packaging and arg handling