### PR TITLE
feat: add syspeek tool to statically generate a syscall profile

### DIFF
--- a/melange.yaml
+++ b/melange.yaml
@@ -58,6 +58,26 @@ subpackages:
             [ -f /usr/bin/ldd-check ]
             [ -x /usr/bin/ldd-check ]
 
+  - name: syspeek
+    options:
+      no-provides: true
+    dependencies:
+      runtime:
+        - apk-tools
+        - binutils
+        - busybox
+        - linux-headers
+        - posix-libc-utils
+    pipeline:
+      - runs: |
+          make -C syspeek MELANGE_CONTEXTDIR=${{targets.contextdir}} melange-install
+    test:
+      pipeline:
+        - runs: |
+            [ -f /usr/bin/syspeek ]
+            [ -x /usr/bin/syspeek ]
+
+
   - name: usrmerge-tool
     options:
       no-provides: true

--- a/syspeek-tool/Makefile
+++ b/syspeek-tool/Makefile
@@ -1,0 +1,13 @@
+PROJECT = syspeek
+MELANGE_CONTEXTDIR ?= /tmp/melange-context/$(PROJECT)
+MELANGE_INSTALL_PATH = $(MELANGE_CONTEXTDIR)/usr/bin
+
+.PHONY: build melange-install
+
+build:
+	chmod +x syspeek
+
+melange-install: build
+	echo $@
+	mkdir -p $(MELANGE_INSTALL_PATH)
+	install -Dm755 $(PROJECT) $(MELANGE_INSTALL_PATH)/$(PROJECT)

--- a/syspeek-tool/README.md
+++ b/syspeek-tool/README.md
@@ -1,0 +1,60 @@
+# `syspeek`
+
+The `syspeek` tool statically analyses an ELF binary by disassembling and reporting a syscall profile.
+
+The syscall profile can then be compared to a one dynamically generated when running functional tests for the same application executable.
+
+The only application type supported are ones compiled. Script and application that use interpreted languages are not supported by this method.
+
+## Requirements
+
+Runtime requirements:
+- binutils (`objdump` tool)
+- syscall table file (`/usr/include/asm/unistd_64.h` by default)
+- `objdump` compiled for the same architecture of the target executable
+
+```shell
+syspeek EXECUTABLE
+```
+
+## Quickstart
+
+```shell
+$ syspeek myapp
+openat
+read
+gettid
+getpid
+gettid
+tgkill
+getpid
+kill
+getpid
+tgkill
+setitimer
+timer_create
+timer_settime
+timer_delete
+mincore
+clock_gettime
+rt_sigprocmask
+rt_sigaction
+mmap
+munmap
+madvise
+futex
+clone
+gettid
+exit
+sigaltstack
+arch_prctl
+sched_yield
+sched_getaffinity
+clock_gettime
+```
+
+## Limitations
+
+There are natural limitations on the static analysis this command does of syscall parameters, due to the nature of the stack and the architecture-specific calling conventions.
+
+Furthermore, some language compilers embeds the runtime into the binary, like Go does. Consequently it requires to filter out runtime's sycalls.

--- a/syspeek-tool/syspeek
+++ b/syspeek-tool/syspeek
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+DEBUG="${DEBUG:-false}"
+debug_log="debug.log"
+objdump=$(command -v objdump)
+ARCH="$($objdump -f ${1} | grep architecture | cut -d ':' -f3 | cut -d ',' -f1)"
+objdump_args="--disassemble --decompress --section .text -M ${ARCH} --source --all-headers --wide"
+
+# TODO: this syscall able is only for the host architecture.
+# get the syscall table for the executable's architecture.
+syscall_table=/usr/include/asm/unistd_64.h
+# X86 64 and 32 bit system call instructions.
+syscall_regex="^(syscall|sysenter)"
+
+# This identifies an op on the accumulator. We look for the syscall identifier.
+rax_mov_regex="^mov.+0x.+,%(r|e)ax$" 
+# We look at mov to other general purpose registers for the syscall parameters.
+params_mov_regex="^mov .+*,%((r|e)bx|(r|e)cx|(r|e)dx|(r|e)si|(r|e)di|(r|e)bp)$"
+
+disassemble() {
+	# Get only assembly opcode column from objdump.
+	awk -F'\t' '{print $3}' \
+		<($objdump $objdump_args "${1}")
+}
+
+# Get the immediate rax set op before syscalls.
+get_syscall_num() {
+	awk "{
+		if (found) {
+			if (\$0 ~ /${rax_mov_regex}/) {
+				print \$0
+				found = 0
+			}
+		}
+		prev = \$0
+		if (\$0 ~ /${syscall_regex}/) {
+			    found = 1
+		}
+	}" <(disassemble $1) | 
+		awk -F' ' '{print $2}' |
+		cut -d ',' -f1
+}
+
+# Get all syscall params from set registers
+# rbx, rcx, rdx, rsi, rdi, rbp.
+get_syscall_params() {
+	awk "{
+		if (found) {
+			if (\$0 ~ /${params_mov_regex}/) {
+				print \$0
+			}
+			if (\$0 ~ /${syscall_regex}/) {
+				found = 0
+				print \$0
+			}
+		}
+		prev = \$0
+		if (\$0 ~ /${syscall_regex}/) {
+			    found = 1
+		}
+	}" <(disassemble $1)
+}
+
+get_syscalls() {
+	# TODO: Literal values (e.g. mov $0xe4,%rax)
+	# Get also register-relative values (e.g. mov 0x8(%rsp),%rax)
+	local literal_args=$(get_syscall_num $1 | grep -F "\$")
+
+	for num in $literal_args; do
+		id=$(hextodec $num)
+		name=$(get_syscall_name $id);
+		if [ -n "${name}" ]; then
+			echo $name
+		else
+			echo "syscall $id not found"
+		fi
+	done
+}
+
+get_syscall_name() {
+	if [ -z "${1}" ]; then
+		echo ""
+		return
+	fi
+	local table=$(grep -E "define __NR_.+ ${1}$" $syscall_table)
+	awk '{print $2}' <(echo ${table//__NR_})
+}
+
+hextodec() {
+	echo $(( 16#${1//[^0-9a-fA-F]/} ))
+}
+
+pretty_echo() {
+	echo >&2 "--- ${1} ---"; echo
+}
+
+main() {
+	if [ "${DEBUG}" == "true" ]; then
+		pretty_echo "Generating debug information. Reference debug.txt for debug purposes."
+		echo "get_syscall_num" >$debug_log
+		get_syscall_num $1 >>$debug_log
+		echo "get_syscall_params" >>$debug_log
+		get_syscall_params $1 >>$debug_log
+	fi
+	get_syscalls $1
+}
+
+main $@


### PR DESCRIPTION
The syspeek tool statically analyses an ELF binary by disassembling and reporting a syscall profile.

The syscall profile can then be compared to a one dynamically generated when running functional tests for the same application executable.

The only application type supported are ones compiled. Script and application that use interpreted languages are not supported by this method.

It needs the syscall table file (`/usr/include/asm/unistd_64.h` by default) and objdump compiled for the same architecture of the target executable.

x86_64 and x86_32 are supported.

For instance:

```shell
$ syspeek myapp
openat
read
gettid
getpid
gettid
tgkill
getpid
kill
getpid
tgkill
setitimer
timer_create
timer_settime
timer_delete
mincore
clock_gettime
rt_sigprocmask
rt_sigaction
mmap
munmap
madvise
futex
clone
gettid
exit
sigaltstack
arch_prctl
sched_yield
sched_getaffinity
clock_gettime
```