### PR TITLE
ldd-check-updates

### DIFF
--- a/ldd-check/ldd-check
+++ b/ldd-check/ldd-check
@@ -16,10 +16,23 @@ while [ $# -ne 0 ]; do
     case "$1" in
         --files=*) files="${files} ${1#*=}";;
         --files) files="${files} $2"; shift;;
-        --packages=*) packages="${packages} ${1#*=}";;
-        --packages) packages="${packages} $2"; shift;;
+        --packages=*)
+            if [ "${1#*=}" = "none" ]; then
+                packages=""
+            else
+                packages="${packages} ${1#*=}"
+            fi
+            ;;
+        --packages)
+            if [ "$2" = "none" ]; then
+                packages=""
+            else
+                packages="${packages} $2"
+            fi
+            shift;;
         --verbose=*) VERBOSE=${1#*=};;
         --verbose) VERBOSE=$2; shift;;
+        --*) error "Unknown argument '$1'";;
     esac
     shift
 done

--- a/ldd-check/ldd-check
+++ b/ldd-check/ldd-check
@@ -38,9 +38,6 @@ while [ $# -ne 0 ]; do
 done
 files=${files# }
 packages=${packages# }
-if [ -n "$packages" ] && [ -n "$files" ]; then
-    error "Cannot provide both packages and files"
-fi
 
 case "$VERBOSE" in
   true|false) :;;
@@ -52,8 +49,6 @@ esac
 tmpd=$(mktemp -d) || fail "ERROR: failed to create tmpdir"
 trap cleanup EXIT
 
-fails=0
-passes=0
 export LANG=C
 
 vmsg() {
@@ -139,6 +134,8 @@ test_files_in() {
   done < "$tmpd/$pkg.list"
 }
 
+fails=0
+passes=0
 set -- $files
 for f in "$@"; do
   check_file "$f" true

--- a/ldd-check/pipelines/test/tw/ldd-check.yaml
+++ b/ldd-check/pipelines/test/tw/ldd-check.yaml
@@ -1,0 +1,28 @@
+name: ldd-check
+
+needs:
+  packages:
+    - ldd-check
+
+inputs:
+  files:
+    description: |
+      The files to run `ldd` on and check for missing deps.
+    required: false
+  packages:
+    description: |
+      Check all binaries in these installed packages
+    required: false
+  verbose:
+    description: |
+      Should the full ldd output be shown
+    required: false
+    default: false
+
+pipeline:
+  - name: "check for missing library dependencies using ldd"
+    runs: |
+      ldd-check \
+          --files="${{inputs.files}}" \
+          --packages="${{inputs.packages}}" \
+          --verbose="${{inputs.verbose}}"

--- a/ldd-check/pipelines/test/tw/ldd-check.yaml
+++ b/ldd-check/pipelines/test/tw/ldd-check.yaml
@@ -11,8 +11,10 @@ inputs:
     required: false
   packages:
     description: |
-      Check all binaries in these installed packages
+      Check all binaries in these installed packages.
+      Use "none" to disable explicit package check.
     required: false
+    default: "${{context.name}}"
   verbose:
     description: |
       Should the full ldd output be shown


### PR DESCRIPTION
* ldd-check - Allow both --packages and --files to be provided.
  
  This actually works in a reasonable way.  The files get
  counted but are required to exist and be something that
  ldd can check, but contents of '--packages' are allowed to be
  "not a dynamic executable".
  
  Also move 'passes' and 'fails' toward the bottom, closer to the
  "main".


* ldd-check - Add support for '--packages=none' for explicit empty packages.

* ldd-check - update pipeline to use context.name by default for packages.
  
  Melange v0.21.2 and newer have support for 'context.name' substitution
  which means most tests can now just have:
  
      uses: test/tw/ldd-check
  
  If you want to use 'files' and do _not_ want to use the default
  packages value, then
  
      uses: test/tw/ldd-check
      with:
        packages: none
        files: /lib/my.library.so


