### PR TITLE
Fix false-negative in exit value of ldd-check.

### DIFF
--- a/ldd-check/ldd-check
+++ b/ldd-check/ldd-check
@@ -146,4 +146,5 @@ for pkg in "$@"; do
 done
 info "tested $((passes+fails)) files with ldd." \
   "$passes passes. $fails fails."
-exit $fails
+
+[ $fails -eq 0 ] || exit 1


### PR DESCRIPTION
ldd-check's exit code would be zero if the number of failures was evenly divisible by 256. Don't `exit $fails`, just `exit 1`.

exit codes are 8 bit. so `exit 256` is the same as `exit 0`.
```
$ sh -c 'exit 256'
$ echo "rc=$?"
0
```