### PR TITLE
Add --configure-opts to pass through compiler flags, etc.

### DIFF
--- a/header-check/Makefile
+++ b/header-check/Makefile
@@ -1,0 +1,13 @@
+PROJECT = header-check
+MELANGE_CONTEXTDIR ?= /tmp/melange-context/$(PROJECT)
+MELANGE_INSTALL_PATH = $(MELANGE_CONTEXTDIR)/usr/bin
+
+.PHONY: build melange-install
+
+build:
+	chmod +x header-check
+
+melange-install: build
+	echo $@
+	mkdir -p $(MELANGE_INSTALL_PATH)
+	install -Dm755 $(PROJECT) $(MELANGE_INSTALL_PATH)/$(PROJECT)

--- a/header-check/Makefile
+++ b/header-check/Makefile
@@ -8,6 +8,5 @@ build:
 	chmod +x header-check
 
 melange-install: build
-	echo $@
 	mkdir -p $(MELANGE_INSTALL_PATH)
 	install -Dm755 $(PROJECT) $(MELANGE_INSTALL_PATH)/$(PROJECT)

--- a/header-check/README.md
+++ b/header-check/README.md
@@ -1,0 +1,5 @@
+# header-check
+
+This is a script that checks the usability of .h and .hpp header files, as installed.
+
+It will generate a basic ```configure.ac``` script, run ```autoconf``` and ```./configure```, and check the header file installed is usable in an ```autoconf``` context.

--- a/header-check/header-check
+++ b/header-check/header-check
@@ -29,12 +29,28 @@ cleanup() {
 	rm -Rf "$tmpd"
 }
 
+configure_opts=""
 files=""
 packages=""
 VERBOSE=false
 
 while [ $# -ne 0 ]; do
 	case "$1" in
+		--configure-opts=*)
+			if [ "${1#*=}" = "none" ]; then
+				configure_opts=""
+			else
+				configure_opts="${configure_opts} ${1#*=}"
+			fi
+		;;
+		--configure-opts)
+			if [ "$2" = "none" ]; then
+				configure_opts=""
+			else
+				configure_opts="${configure_opts} $2"
+			fi
+			shift
+		;;
 		--files=*)
 			files="${files} ${1#*=}"
 		;;
@@ -70,6 +86,7 @@ while [ $# -ne 0 ]; do
 	esac
 	shift
 done
+configure_opts=${configure_opts# }
 files=${files# }
 packages=${packages# }
 
@@ -90,6 +107,8 @@ trap cleanup EXIT
 test_header() {
 	local lang="$1"
 	local header="$2"
+	local configure_opts="$3"
+	local flags=
 	local rc=1
 	d=$(mktemp -d $tmpd/XXXXXXXX)
 	cd $d
@@ -106,7 +125,7 @@ test_header() {
 	esac
 	cat configure.ac
 	autoconf
-	./configure && rc=0 || rc=1
+	./configure "$configure_opts" && rc=0 || rc=1
 	cat config.log
 	cd ..
 	rm -rf $d
@@ -145,7 +164,7 @@ set -- $files
 for f in "$@"; do
 	success=false
 	for lang in "c" "cpp"; do
-		if test_header "$lang" "$f"; then
+		if test_header "$lang" "$f" "$configure_opts"; then
 			pass "header test [$f]"
 			success=true
 			break
@@ -162,7 +181,7 @@ for pkg in "$@"; do
 	for f in $(apk info -qL "$pkg" | grep "^usr/include/.*\.h[p]*$" | sed -e "s:^usr/include/::"); do
 		success=false
 		for lang in "c" "cpp"; do
-			if test_header "$lang" "$f"; then
+			if test_header "$lang" "$f" "$configure_opts"; then
 				success=true
 				pass "Success testing header [$f]"
 				break

--- a/header-check/header-check
+++ b/header-check/header-check
@@ -159,7 +159,7 @@ for f in "$@"; do
 done
 set -- $packages
 for pkg in "$@"; do
-	for f in $(apk info -L "$pkg" 2>/dev/null | grep "^usr/include/.*\.h[p]*$" | sed -e "s:^usr/include/::"); do
+	for f in $(apk info -qL "$pkg" | grep "^usr/include/.*\.h[p]*$" | sed -e "s:^usr/include/::"); do
 		success=false
 		for lang in "c" "cpp"; do
 			if test_header "$lang" "$f"; then
@@ -176,4 +176,8 @@ for pkg in "$@"; do
 	done
 done
 info "tested [$((PASSES+FAILS))] files with $PROG.  [$PASSES] passes. [$FAILS] fails."
-exit $FAILS
+if [ "$FAILS" = "0" ]; then
+	exit 0
+else
+	exit 1
+fi

--- a/header-check/header-check
+++ b/header-check/header-check
@@ -153,10 +153,8 @@ for f in "$@"; do
 			success=false
 		fi
 	done
-	if [ "$success" = "true" ]; then
-		pass "Success testing header [/usr/include/$f]"
-	else
-		fail "Failure testing header [/usr/include/$f]"
+	if [ "$success" = "false" ]; then
+		fail "Failure testing header [$f]"
 	fi
 done
 set -- $packages
@@ -166,14 +164,14 @@ for pkg in "$@"; do
 		for lang in "c" "cpp"; do
 			if test_header "$lang" "$f"; then
 				success=true
-				pass "Success testing header [/usr/include/$f]"
+				pass "Success testing header [$f]"
 				break
 			else
 				success=false
 			fi
 		done
 		if [ "$success" = "false" ]; then
-			fail "Failure testing header [/usr/include/$f]"
+			fail "Failure testing header [$f]"
 		fi
 	done
 done

--- a/header-check/header-check
+++ b/header-check/header-check
@@ -174,5 +174,5 @@ for pkg in "$@"; do
 		fail "Failure testing header [/usr/include/$f]"
 	fi
 done
-info "tested [$((passes+fails))] files with ldd.  [$passes] passes. [$fails] fails."
+info "tested [$((passes+fails))] files with $PROG.  [$passes] passes. [$fails] fails."
 exit $fails

--- a/header-check/header-check
+++ b/header-check/header-check
@@ -16,12 +16,12 @@ error() {
 
 fail() {
 	echo "FAIL[$PROG]:" "$@"
-	fails=$((fails+1))
+	FAILS=$((FAILS+1))
 }
 
 pass() {
 	echo "PASS[$PROG]:" "$@"
-	passes=$((passes+1))
+	PASSES=$((PASSES+1))
 }
 
 cleanup() {
@@ -139,8 +139,8 @@ AC_OUTPUT()
 EOF
 }
 
-fails=0
-passes=0
+FAILS=0
+PASSES=0
 set -- $files
 for f in "$@"; do
 	success=false
@@ -149,6 +149,8 @@ for f in "$@"; do
 			pass "header test [$f]"
 			success=true
 			break
+		else
+			success=false
 		fi
 	done
 	if [ "$success" = "true" ]; then
@@ -164,15 +166,16 @@ for pkg in "$@"; do
 		for lang in "c" "cpp"; do
 			if test_header "$lang" "$f"; then
 				success=true
+				pass "Success testing header [/usr/include/$f]"
 				break
+			else
+				success=false
 			fi
 		done
+		if [ "$success" = "false" ]; then
+			fail "Failure testing header [/usr/include/$f]"
+		fi
 	done
-	if [ "$success" = "true" ]; then
-		pass "Success testing header [/usr/include/$f]"
-	else
-		fail "Failure testing header [/usr/include/$f]"
-	fi
 done
-info "tested [$((passes+fails))] files with $PROG.  [$passes] passes. [$fails] fails."
-exit $fails
+info "tested [$((PASSES+FAILS))] files with $PROG.  [$PASSES] passes. [$FAILS] fails."
+exit $FAILS

--- a/header-check/header-check
+++ b/header-check/header-check
@@ -1,0 +1,178 @@
+#!/bin/sh
+# shellcheck disable=SC2317,SC2166,SC3043,SC2162,SC2086
+set +x
+set -f
+
+PROG="header-check"
+
+info() {
+	echo "INFO[$PROG]:" "$@"
+}
+
+error() {
+	echo "ERROR[$PROG]:" "$@"
+	exit 1
+}
+
+fail() {
+	echo "FAIL[$PROG]:" "$@"
+	fails=$((fails+1))
+}
+
+pass() {
+	echo "PASS[$PROG]:" "$@"
+	passes=$((passes+1))
+}
+
+cleanup() {
+	[ -n "$tmpd" -o -z "$tmpd" ] && return 0
+	rm -Rf "$tmpd"
+}
+
+files=""
+packages=""
+VERBOSE=false
+
+while [ $# -ne 0 ]; do
+	case "$1" in
+		--files=*)
+			files="${files} ${1#*=}"
+		;;
+		--files)
+			files="${files} $2"
+			shift
+		;;
+		--packages=*)
+			if [ "${1#*=}" = "none" ]; then
+				packages=""
+			else
+				packages="${packages} ${1#*=}"
+			fi
+		;;
+		--packages)
+			if [ "$2" = "none" ]; then
+				packages=""
+			else
+				packages="${packages} $2"
+			fi
+			shift
+		;;
+		--verbose=*)
+			VERBOSE=${1#*=}
+		;;
+		--verbose)
+			VERBOSE=$2
+			shift
+		;;
+        	--*)
+			error "Unknown argument '$1'"
+		;;
+	esac
+	shift
+done
+files=${files# }
+packages=${packages# }
+
+case "$VERBOSE" in
+	true|false)
+		:
+	;;
+	*)
+		error "--verbose must be 'true' or 'false'. found '$VERBOSE'"
+	;;
+esac
+
+[ -n "${files}${packages}" ] || error "No files or packages specified"
+
+tmpd=$(mktemp -d) || fail "ERROR: failed to create tmpdir"
+trap cleanup EXIT
+
+test_header() {
+	local lang="$1"
+	local header="$2"
+	local rc=1
+	d=$(mktemp -d $tmpd/XXXXXXXX)
+	cd $d
+	case $lang in
+		c)
+			gen_c_ac "$header"
+		;;
+		cpp)
+			gen_cpp_ac "$header"
+		;;
+		*)
+			return 1
+		;;
+	esac
+	cat configure.ac
+	autoconf
+	./configure && rc=0 || rc=1
+	cat config.log
+	cd ..
+	rm -rf $d
+	return $rc
+}
+
+gen_c_ac() {
+	local f="$1"
+	cat >configure.ac <<EOF
+AC_INIT([example],[1.0],[example@example.com])
+AC_PREREQ(2.69)
+AC_PROG_CC
+AC_LANG(C)
+AC_CHECK_HEADER($f,[c_header_found=yes],,)
+AS_IF([test "x\$c_header_found" != "xyes"], [AC_MSG_ERROR([Unable to check header])])
+AC_OUTPUT()
+EOF
+}
+
+gen_cpp_ac() {
+	local f="$1"
+	cat >configure.ac <<EOF
+AC_INIT([example],[1.0],[example@example.com])
+AC_PREREQ(2.69)
+AC_PROG_CXX
+AC_LANG(C++)
+AC_CHECK_HEADER($f,[cxx_header_found=yes],,)
+AS_IF([test "x\$cxx_header_found" != "xyes"], [AC_MSG_ERROR([Unable to check header])])
+AC_OUTPUT()
+EOF
+}
+
+fails=0
+passes=0
+set -- $files
+for f in "$@"; do
+	success=false
+	for lang in "c" "cpp"; do
+		if test_header "$lang" "$f"; then
+			pass "header test [$f]"
+			success=true
+			break
+		fi
+	done
+	if [ "$success" = "true" ]; then
+		pass "Success testing header [/usr/include/$f]"
+	else
+		fail "Failure testing header [/usr/include/$f]"
+	fi
+done
+set -- $packages
+for pkg in "$@"; do
+	for f in $(apk info -L "$pkg" 2>/dev/null | grep "^usr/include/.*\.h[p]*$" | sed -e "s:^usr/include/::"); do
+		success=false
+		for lang in "c" "cpp"; do
+			if test_header "$lang" "$f"; then
+				success=true
+				break
+			fi
+		done
+	done
+	if [ "$success" = "true" ]; then
+		pass "Success testing header [/usr/include/$f]"
+	else
+		fail "Failure testing header [/usr/include/$f]"
+	fi
+done
+info "tested [$((passes+fails))] files with ldd.  [$passes] passes. [$fails] fails."
+exit $fails

--- a/pipelines/test/tw/header-check.yaml
+++ b/pipelines/test/tw/header-check.yaml
@@ -1,0 +1,16 @@
+name: headers
+needs:
+  packages:
+   - autoconf
+   - build-base
+
+inputs:
+  packages:
+    description: check the header files in provided packages
+    required: false
+    default: "${{context.name}}"
+
+pipeline:
+  - name: check header files using header-check
+    runs: |
+      header-check "--packages=${{context.name}}"


### PR DESCRIPTION
Some header checks will require additional options and flags to ./configure

See: libb64-1.2 as an example.

This change adds an optional --configure-opts parameter.