### PR TITLE
Add --configure-opts to pass through compiler flags, etc.

### DIFF
--- a/header-check/header-check
+++ b/header-check/header-check
@@ -29,12 +29,28 @@ cleanup() {
 	rm -Rf "$tmpd"
 }
 
+configure_opts=""
 files=""
 packages=""
 VERBOSE=false
 
 while [ $# -ne 0 ]; do
 	case "$1" in
+		--configure-opts=*)
+			if [ "${1#*=}" = "none" ]; then
+				configure_opts=""
+			else
+				configure_opts="${configure_opts} ${1#*=}"
+			fi
+		;;
+		--configure-opts)
+			if [ "$2" = "none" ]; then
+				configure_opts=""
+			else
+				configure_opts="${configure_opts} $2"
+			fi
+			shift
+		;;
 		--files=*)
 			files="${files} ${1#*=}"
 		;;
@@ -70,6 +86,7 @@ while [ $# -ne 0 ]; do
 	esac
 	shift
 done
+configure_opts=${configure_opts# }
 files=${files# }
 packages=${packages# }
 
@@ -90,6 +107,7 @@ trap cleanup EXIT
 test_header() {
 	local lang="$1"
 	local header="$2"
+	local configure_opts="$3"
 	local rc=1
 	d=$(mktemp -d $tmpd/XXXXXXXX)
 	cd $d
@@ -106,7 +124,7 @@ test_header() {
 	esac
 	cat configure.ac
 	autoconf
-	./configure && rc=0 || rc=1
+	./configure "$configure_opts" && rc=0 || rc=1
 	cat config.log
 	cd ..
 	rm -rf $d
@@ -145,7 +163,7 @@ set -- $files
 for f in "$@"; do
 	success=false
 	for lang in "c" "cpp"; do
-		if test_header "$lang" "$f"; then
+		if test_header "$lang" "$f" "$configure_opts"; then
 			pass "header test [$f]"
 			success=true
 			break
@@ -162,7 +180,7 @@ for pkg in "$@"; do
 	for f in $(apk info -qL "$pkg" | grep "^usr/include/.*\.h[p]*$" | sed -e "s:^usr/include/::"); do
 		success=false
 		for lang in "c" "cpp"; do
-			if test_header "$lang" "$f"; then
+			if test_header "$lang" "$f" "$configure_opts"; then
 				success=true
 				pass "Success testing header [$f]"
 				break

--- a/header-check/header-check
+++ b/header-check/header-check
@@ -124,7 +124,7 @@ test_header() {
 	esac
 	cat configure.ac
 	autoconf
-	./configure "$configure_opts" && rc=0 || rc=1
+	./configure $configure_opts && rc=0 || rc=1
 	cat config.log
 	cd ..
 	rm -rf $d

--- a/pipelines/test/tw/header-check.yaml
+++ b/pipelines/test/tw/header-check.yaml
@@ -8,6 +8,10 @@ inputs:
     description: check the header files in provided packages
     required: false
     default: "${{context.name}}"
+  configure-opts:
+    description: any additional configure options required for the headers in this package
+    required: false
+    default: ""
 
 pipeline:
   - name: check header files using header-check


### PR DESCRIPTION
Cleaner PR, supporting passthrough input for ./configure options.  Needed for some header tests, such as libb64-1.2