### PR TITLE
add a test that checks a ruby gem installation

### DIFF
--- a/gem-check/Makefile
+++ b/gem-check/Makefile
@@ -1,0 +1,12 @@
+PROJECT = gem-check
+MELANGE_CONTEXTDIR ?= /tmp/melange-context/$(PROJECT)
+MELANGE_INSTALL_PATH = $(MELANGE_CONTEXTDIR)/usr/bin
+
+.PHONY: build melange-install
+
+build:
+	chmod +x gem-check
+
+melange-install: build
+	mkdir -p $(MELANGE_INSTALL_PATH)
+	install -Dm755 $(PROJECT) $(MELANGE_INSTALL_PATH)/$(PROJECT)

--- a/gem-check/README.md
+++ b/gem-check/README.md
@@ -1,0 +1,5 @@
+# gem-check
+
+This is a script that checks the viability of a ruby gem, as installed.
+
+It will ensure that ```gem list``` is able to find the gem, and that ```ruby``` is able to ```require``` the gem.

--- a/gem-check/gem-check
+++ b/gem-check/gem-check
@@ -1,0 +1,109 @@
+#!/bin/sh
+# shellcheck disable=SC2317,SC2166,SC3043,SC2162,SC2086
+set +x
+set -f
+
+PROG="gem-check"
+
+info() {
+	echo "INFO[$PROG]:" "$@"
+}
+
+error() {
+	echo "ERROR[$PROG]:" "$@"
+	exit 1
+}
+
+fail() {
+	echo "FAIL[$PROG]:" "$@"
+	FAILS=$((FAILS+1))
+}
+
+pass() {
+	echo "PASS[$PROG]:" "$@"
+	PASSES=$((PASSES+1))
+}
+
+packages=""
+require=""
+VERBOSE=false
+
+while [ $# -ne 0 ]; do
+	case "$1" in
+		--packages=*)
+			if [ "${1#*=}" = "none" ]; then
+				packages=""
+			else
+				packages="${packages} ${1#*=}"
+			fi
+		;;
+		--packages)
+			if [ "$2" = "none" ]; then
+				packages=""
+			else
+				packages="${packages} $2"
+			fi
+			shift
+		;;
+		--require=*)
+			if [ "${1#*=}" = "none" ]; then
+				require=""
+			else
+				require="${require} ${1#*=}"
+			fi
+		;;
+		--verbose=*)
+			VERBOSE=${1#*=}
+		;;
+		--verbose)
+			VERBOSE=$2
+			shift
+		;;
+        	--*)
+			error "Unknown argument '$1'"
+		;;
+	esac
+	shift
+done
+packages=${packages# }
+require=${require# }
+
+case "$VERBOSE" in
+	true|false)
+		:
+	;;
+	*)
+		error "--verbose must be 'true' or 'false'. found '$VERBOSE'"
+	;;
+esac
+
+[ -n "${packages}" ] || error "No files or packages specified"
+
+FAILS=0
+PASSES=0
+set -- $packages
+for pkg in "$@"; do
+	gem_dash=$(echo "$pkg" | sed -e "s/^ruby[0-9\.]\+-//")
+	gem_slash=$(echo "$pkg" | sed -e "s/^ruby[0-9\.]\+-//" -e "s:\-:/:g")
+	if [ $(gem list -i "^$gem_dash$") = "true" ]; then
+		pass "Success listing gem [$gem_dash]"
+	else
+		fail "Failed listing gem [$gem_dash]"
+	fi
+	if [ -z "$require" ]; then
+		require="$gem_slash"
+	fi
+	for req in "$require"; do
+		if ruby -e "require '$req'"; then
+			pass "Success requiring gem [$req]"
+		else
+			fail "Failed requiring gem [$req]"
+		fi
+	done
+done
+info "tested [$((PASSES+FAILS))] files with $PROG.  [$PASSES] passes. [$FAILS] fails."
+if [ "$FAILS" = "0" ]; then
+	exit 0
+else
+	exit 1
+fi

--- a/gem-check/gem-check
+++ b/gem-check/gem-check
@@ -1,6 +1,5 @@
 #!/bin/sh
 # shellcheck disable=SC2317,SC2166,SC3043,SC2162,SC2086
-set +x
 set -f
 
 PROG="gem-check"

--- a/gem-check/gem-check
+++ b/gem-check/gem-check
@@ -24,6 +24,23 @@ pass() {
 	PASSES=$((PASSES+1))
 }
 
+gem_list() {
+	local gpkg="$1" out="" rc=""
+	# 'gem list -i pkg' should echo "true" and exit 0 on "gem found"
+	# and echo "false" and exit 1 on "not found"
+	out=$(gem list -i "$gpkg")
+	rc=$?
+	case "$rc:$out" in
+		0:true)
+			return 0
+		;;
+		1:false)
+			return 1
+		;;
+	esac
+	error "'gem list -i $gpkg' had unexpected exited $rc with output '$output'"
+}
+
 packages=""
 require=""
 VERBOSE=false
@@ -106,11 +123,13 @@ for pkg in "$@"; do
 	#
 	gem_dash=$(echo "$pkg" | sed -e "s/^ruby[0-9\.]\+-//")
 	gem_slash=$(echo "$pkg" | sed -e "s/^ruby[0-9\.]\+-//" -e "s:\-:/:g")
-	if [ $(gem list -i "^$gem_dash$") = "true" ]; then
+	# Test listing the gem
+	if gem_list "$gpkg" ; then
 		pass "Success listing gem [$gem_dash]"
 	else
 		fail "Failed listing gem [$gem_dash]"
 	fi
+	# Test requiring the gem in ruby code
 	if [ -z "$require" ]; then
 		require="$gem_slash"
 	fi

--- a/gem-check/gem-check
+++ b/gem-check/gem-check
@@ -70,39 +70,39 @@ exit 9
 	return 1
 }
 
-packages=""
+package=""
 require=""
-VERBOSE=false
 
 while [ $# -ne 0 ]; do
 	case "$1" in
-		--packages=*)
+		-p=*|--package=*)
 			if [ "${1#*=}" = "none" ]; then
-				packages=""
+				package=""
 			else
-				packages="${packages} ${1#*=}"
+				package="${1#*=}"
 			fi
 		;;
-		--packages)
+		-p|--package)
 			if [ "$2" = "none" ]; then
-				packages=""
+				package=""
 			else
-				packages="${packages} $2"
+				package="$2"
 			fi
 			shift
 		;;
-		--require=*)
+		-r=*|--require=*)
 			if [ "${1#*=}" = "none" ]; then
 				require=""
 			else
-				require="${require} ${1#*=}"
+				require="${1#*=}"
 			fi
 		;;
-		--verbose=*)
-			VERBOSE=${1#*=}
-		;;
-		--verbose)
-			VERBOSE=$2
+		-r|--require)
+			if [ "${1#*=}" = "none" ]; then
+				require=""
+			else
+				require="$2"
+			fi
 			shift
 		;;
         	--*)
@@ -111,65 +111,54 @@ while [ $# -ne 0 ]; do
 	esac
 	shift
 done
-packages=${packages# }
+package=${package# }
 require=${require# }
 
-case "$VERBOSE" in
-	true|false)
-		:
-	;;
-	*)
-		error "--verbose must be 'true' or 'false'. found '$VERBOSE'"
-	;;
-esac
-
-[ -n "${packages}" ] || error "No files or packages specified"
+[ -n "${package}" ] || error "No package specified"
 
 FAILS=0
 PASSES=0
-set -- $packages
-for pkg in "$@"; do
-	#
-	# Packages are apk-compatible package names such as:
-	#   $ gem-check --packages="ruby3.2-tzinfo ruby3.2-quantile ruby3.2-net-http-persistent"
-	#
-	# gem_dash is a reasonable "guess" at the gem name, such that
-	# package=ruby3.2-net-http-persistent becomes gem_dash=net-http-persistent
-	# and can be passed to "gem list -i ..."
-        #   $ gem list -i "^net-http-persistent$"
-	#   true
-	#
-	# gem_slash is a reasonable "guess" at the library name that can be "required" inside of some ruby code
-	#   package=ruby3.2-net-http-persistent comes gem_slash=net/http/persistent
-	#   $ ruby -e "require 'net/http/persistent'"
-	#
-	# If this script can't accurately guess the gem name to require,
-	# then the test writer can specify with:
-	#   $ gem-check --packages=ruby3.2-rubyzip --require=zip
-	#   PASS[gem-check]: Success listing gem [rubyzip]
-	#   PASS[gem-check]: Success requiring gem [zip]
-	#   INFO[gem-check]: tested [2] files with gem-check.  [2] passes. [0] fails.
-	#
-	gem_dash=$(echo "$pkg" | sed -e "s/^ruby[0-9\.]\+-//")
-	gem_slash=$(echo "$pkg" | sed -e "s/^ruby[0-9\.]\+-//" -e "s:\-:/:g")
-	# Test listing the gem
-	if gem_list "$gpkg" ; then
-		pass "Success listing gem [$gem_dash]"
+#
+# Packages are apk-compatible package names such as:
+#   $ gem-check --package="ruby3.2-net-http-persistent"
+#
+# gem_dash is a reasonable "guess" at the gem name, such that
+# package=ruby3.2-net-http-persistent becomes gem_dash=net-http-persistent
+# and can be passed to "gem list -i ..."
+#   $ gem list -i "^net-http-persistent$"
+#   true
+#
+# gem_slash is a reasonable "guess" at the library name that can be "required" inside of some ruby code
+#   package=ruby3.2-net-http-persistent comes gem_slash=net/http/persistent
+#   $ ruby -e "require 'net/http/persistent'"
+#
+# If this script can't accurately guess the gem name to require,
+# then the test writer can specify with:
+#   $ gem-check --package=ruby3.2-rubyzip --require=zip
+#   PASS[gem-check]: Success listing gem [rubyzip]
+#   PASS[gem-check]: Success requiring gem [zip]
+#   INFO[gem-check]: tested [2] files with gem-check.  [2] passes. [0] fails.
+#
+gem_dash=$(echo "$package" | sed -e "s/^ruby[0-9\.]\+-//")
+gem_slash=$(echo "$package" | sed -e "s/^ruby[0-9\.]\+-//" -e "s:\-:/:g")
+# Test listing the gem
+if gem_list "$gem_dash" ; then
+	pass "Success listing gem [$gem_dash]"
+else
+	fail "Failed listing gem [$gem_dash]"
+fi
+# Test requiring the gem in ruby code
+if [ -z "$require" ]; then
+	require="$gem_slash"
+fi
+for req in "$require"; do
+	if gem_require "$req" ; then
+		pass "Success requiring gem [$req]"
 	else
-		fail "Failed listing gem [$gem_dash]"
+		fail "Failed requiring gem [$req]"
 	fi
-	# Test requiring the gem in ruby code
-	if [ -z "$require" ]; then
-		require="$gem_slash"
-	fi
-	for req in "$require"; do
-		if gem_require "$req" ; then
-			pass "Success requiring gem [$req]"
-		else
-			fail "Failed requiring gem [$req]"
-		fi
-	done
 done
+
 info "tested [$((PASSES+FAILS))] files with $PROG.  [$PASSES] passes. [$FAILS] fails."
 if [ "$FAILS" = "0" ]; then
 	exit 0

--- a/gem-check/gem-check
+++ b/gem-check/gem-check
@@ -41,6 +41,35 @@ gem_list() {
 	error "'gem list -i $gpkg' had unexpected exited $rc with output '$output'"
 }
 
+gem_require() {
+	local g="$1" out="" rc=""
+	out=$(ruby -e '
+#!/usr/bin/ruby
+r = ARGV[0]
+begin
+  require r
+  print "pass"
+  exit 0
+rescue LoadError => error
+  print "require #{r}: #{error}"
+  exit 3
+end
+exit 9
+' "$g" 2>&1)
+	rc=$?
+	case "$rc:$out" in
+		0:pass)
+			return 0
+		;;
+		3:*)
+			echo "$out";
+			return 1
+		;;
+	esac
+	error "Unexpected error in ruby require test for '$r' [$rc]: $out"
+	return 1
+}
+
 packages=""
 require=""
 VERBOSE=false
@@ -134,7 +163,7 @@ for pkg in "$@"; do
 		require="$gem_slash"
 	fi
 	for req in "$require"; do
-		if ruby -e "require '$req'"; then
+		if gem_require "$req" ; then
 			pass "Success requiring gem [$req]"
 		else
 			fail "Failed requiring gem [$req]"

--- a/gem-check/gem-check
+++ b/gem-check/gem-check
@@ -83,6 +83,27 @@ FAILS=0
 PASSES=0
 set -- $packages
 for pkg in "$@"; do
+	#
+	# Packages are apk-compatible package names such as:
+	#   $ gem-check --packages="ruby3.2-tzinfo ruby3.2-quantile ruby3.2-net-http-persistent"
+	#
+	# gem_dash is a reasonable "guess" at the gem name, such that
+	# package=ruby3.2-net-http-persistent becomes gem_dash=net-http-persistent
+	# and can be passed to "gem list -i ..."
+        #   $ gem list -i "^net-http-persistent$"
+	#   true
+	#
+	# gem_slash is a reasonable "guess" at the library name that can be "required" inside of some ruby code
+	#   package=ruby3.2-net-http-persistent comes gem_slash=net/http/persistent
+	#   $ ruby -e "require 'net/http/persistent'"
+	#
+	# If this script can't accurately guess the gem name to require,
+	# then the test writer can specify with:
+	#   $ gem-check --packages=ruby3.2-rubyzip --require=zip
+	#   PASS[gem-check]: Success listing gem [rubyzip]
+	#   PASS[gem-check]: Success requiring gem [zip]
+	#   INFO[gem-check]: tested [2] files with gem-check.  [2] passes. [0] fails.
+	#
 	gem_dash=$(echo "$pkg" | sed -e "s/^ruby[0-9\.]\+-//")
 	gem_slash=$(echo "$pkg" | sed -e "s/^ruby[0-9\.]\+-//" -e "s:\-:/:g")
 	if [ $(gem list -i "^$gem_dash$") = "true" ]; then

--- a/header-check/header-check
+++ b/header-check/header-check
@@ -1,6 +1,5 @@
 #!/bin/sh
 # shellcheck disable=SC2317,SC2166,SC3043,SC2162,SC2086
-set -e
 set -f
 
 PROG="header-check"

--- a/header-check/header-check
+++ b/header-check/header-check
@@ -1,6 +1,6 @@
 #!/bin/sh
 # shellcheck disable=SC2317,SC2166,SC3043,SC2162,SC2086
-set +x
+set -e
 set -f
 
 PROG="header-check"

--- a/melange.yaml
+++ b/melange.yaml
@@ -58,6 +58,22 @@ subpackages:
             [ -f /usr/bin/ldd-check ]
             [ -x /usr/bin/ldd-check ]
 
+  - name: gem-check
+    options:
+      no-provides: true
+    dependencies:
+      runtime:
+        - apk-tools
+        - busybox
+    pipeline:
+      - runs: |
+          make -C header-check MELANGE_CONTEXTDIR=${{targets.contextdir}} melange-install
+    test:
+      pipeline:
+        - runs: |
+            [ -f /usr/bin/gem-check ]
+            [ -x /usr/bin/gem-check ]
+
   - name: header-check
     options:
       no-provides: true

--- a/pipelines/test/tw/gem-check.yaml
+++ b/pipelines/test/tw/gem-check.yaml
@@ -1,0 +1,19 @@
+name: gem-check
+needs:
+  packages:
+    - gem-check
+
+inputs:
+  packages:
+    description: package(s) containing a ruby gem
+    required: false
+    default: "${{context.name}}"
+  require:
+    description: optional string of exact gem name to require
+    required: false
+    default: ""
+
+pipeline:
+  - name: check a ruby gem installation
+    runs: |
+      gem-check --packages="${{inputs.packages}}" --require="${{inputs.require}}"

--- a/pipelines/test/tw/gem-check.yaml
+++ b/pipelines/test/tw/gem-check.yaml
@@ -4,16 +4,16 @@ needs:
     - gem-check
 
 inputs:
-  packages:
-    description: package(s) containing a ruby gem
+  package:
+    description: package containing a ruby gem
     required: false
     default: "${{context.name}}"
   require:
-    description: optional string of exact gem name to require
+    description: exact gem name(s) to test requiring (this overrides the script-guessed gem name)
     required: false
     default: ""
 
 pipeline:
   - name: check a ruby gem installation
     runs: |
-      gem-check --packages="${{inputs.packages}}" --require="${{inputs.require}}"
+      gem-check --package "${{inputs.package}}" --require "${{inputs.require}}"

--- a/pipelines/test/tw/gem-check.yaml
+++ b/pipelines/test/tw/gem-check.yaml
@@ -2,6 +2,9 @@ name: gem-check
 needs:
   packages:
     - gem-check
+# Note -- we're not going to require 'ruby' or 'gem' here, because:
+#   - these packages should depend on the correct version of ruby and gem
+#     and the tests should fail otherwise...:
 
 inputs:
   package:


### PR DESCRIPTION
Here's another test check that will check ruby gem installs.

I've run it (manually), and have successful runs from:

1. ruby3.2-json-jwt
2. ruby3.2-jwt
3. ruby3.2-mail
4. ruby3.2-method_source
5. ruby3.2-mini_mime
6. ruby3.2-minitar
7. ruby3.2-multi_json
8. ruby3.2-multi_xml
9. ruby3.2-net-http-persistent
10. ruby3.2-net-protocol
11. ruby3.2-numerizer
12. ruby3.2-openssl_pkcs8_pure
13. ruby3.2-polyglot
14. ruby3.2-protocol-hpack
15. ruby3.2-public_suffix
16. ruby3.2-quantile
17. ruby3.2-rack-oauth2
18. ruby3.2-redis-namespace
19. ruby3.2-redis
20. ruby3.2-rexml
21. ruby3.2-ruby2_keywords
22. ruby3.2-serverengine
23. ruby3.2-sigdump
24. ruby3.2-snaky_hash
25. ruby3.2-swd
26. ruby3.2-thread_safe
27. ruby3.2-timeout
28. ruby3.2-tzinfo-data
29. ruby3.2-tzinfo
30. ruby3.2-validate_email
31. ruby3.2-validate_url
32. ruby3.2-webfinger