### PR TITLE
kgrep: default to default namespace

### DIFF
--- a/tw/pkg/commands/kgrep/kgrep.go
+++ b/tw/pkg/commands/kgrep/kgrep.go
@@ -55,7 +55,7 @@ func Command() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVarP(&cfg.Namespace, "namespace", "n", "", "namespace to install the release into")
+	cmd.Flags().StringVarP(&cfg.Namespace, "namespace", "n", "default", "namespace to install the release into")
 	cmd.Flags().DurationVarP(&cfg.Timeout, "timeout", "t", DefaultTimeout, "time to wait for logs to appear")
 	cmd.Flags().IntVarP(&cfg.Retry, "retry", "r", 0, "number of times to retry a failed request")
 	cmd.Flags().BoolVarP(&cfg.IgnoreCase, "ignore-case", "i", false, "toggle to ignore case for the match")


### PR DESCRIPTION
being explicit is good but default is a good default to default to similar to kubectl and kimages. :)

missed this while writing tests. 