### PR TITLE
tools/release-to-wolfi - replace getopt with getopts (plural/builtin)

### DIFF
--- a/melange.yaml
+++ b/melange.yaml
@@ -19,11 +19,11 @@ environment:
       - go
 
 pipeline:
-  # - uses: git-checkout
-  #   with:
-  #     repository: https://github.com/chainguard-dev/tw
-  #     tag: v${{package.version}}
-  #     expected-commit: 52c18c170c1cdbca5ec6b53aa0bfdb0b8d376746
+  #wolfi#- uses: git-checkout
+  #wolfi#  with:
+  #wolfi#    repository: https://github.com/chainguard-dev/tw
+  #wolfi#    tag: v${{package.version}}
+  #wolfi#   expected-commit: 52c18c170c1cdbca5ec6b53aa0bfdb0b8d376746
 
   # Make the tw binary in the main package so we don't end up with `tw-tw`
   - runs: |

--- a/tools/release-to-wolfi
+++ b/tools/release-to-wolfi
@@ -28,25 +28,19 @@ debug() {
 }
 
 main() {
-	local short_opts="hv"
-	local long_opts="help,verbose"
-	local getopt_out=""
-	getopt_out=$(getopt --name "${0##*/}" \
-		--options "${short_opts}" --long "${long_opts}" -- "$@") &&
-		eval set -- "${getopt_out}" ||
-		{ bad_Usage; return; }
+	[ "$1" = "--help" ] && { Usage; exit 0; }
 
-	local cur="" next=""
-	while [ $# -ne 0 ]; do
-		# shellcheck disable=SC2034
-		{ cur="$1"; next="$2"; }
-		case "$cur" in
-			-h|--help) Usage ; exit 0;;
-			-v|--verbose) VERBOSITY=$((VERBOSITY+1));;
-			--) shift; break;;
+	while getopts "hv" opt; do
+		case "$opt" in
+			h) Usage; exit 0;;
+			v) VERBOSITY=$((VERBOSITY+1));;
+			\?) Usage 1>&2;
+				stderr "invalid option -$OPTARG"
+				exit 1;;
 		esac
-		shift;
 	done
+
+	shift $((OPTIND -1))
 
 	[ $# -eq 2 ] || { bad_Usage "got $# args expected 2"; return 1; }
 

--- a/tools/release-to-wolfi
+++ b/tools/release-to-wolfi
@@ -64,6 +64,7 @@ main() {
 	# search only in lines 1 to 10 for version and epoch
 	sed -e "1,10s/^\([ ]\+version\): .*/\1: ${tag#v}/" \
 	    -e "1,10s,^\([ ]\+epoch\): .*,\1: 0," \
+	    -e "s,#wolfi#,," \
 	    -e "s,^\([ ]\+expected-commit\): .*$,\1: $cksum," \
 		"melange.yaml" > "$gdir/tw.yaml"
 	( cd "$gdir" && git add tw.yaml )


### PR DESCRIPTION
getopts is shell builtin.
getopt is way nicer and supports long options.
getopt on mac is some random thing that doesn't behave in a sensical way.

Per Josh:

    $ ./tools/release-to-wolfi v0.0.8 ~/dev/gh/wolfi/os
    Usage: release-to-wolfi tag wolfi-os/

       Release 'tag' to wolfi, where 'wolfi-os' is a wolfi-dev/os
       git checkout.
    got 8 args expected 2

Thanks mac.