### PR TITLE
Fixup release script again.

### DIFF
--- a/melange.yaml
+++ b/melange.yaml
@@ -23,7 +23,7 @@ pipeline:
   #wolfi#  with:
   #wolfi#    repository: https://github.com/chainguard-dev/tw
   #wolfi#    tag: v${{package.version}}
-  #wolfi#   expected-commit: 52c18c170c1cdbca5ec6b53aa0bfdb0b8d376746
+  #wolfi#    expected-commit: 52c18c170c1cdbca5ec6b53aa0bfdb0b8d376746
 
   # Make the tw binary in the main package so we don't end up with `tw-tw`
   - runs: |

--- a/tools/release-to-wolfi
+++ b/tools/release-to-wolfi
@@ -1,7 +1,8 @@
 #!/bin/sh
 # shellcheck disable=SC2015,SC2039,SC2166,SC3043
 VERBOSITY=0
-TWGIT=https://github.com/chainguard-dev/tw
+# run with 'TWGIT=$PWD' to test locally
+TWGIT=${TWGIT:-https://github.com/chainguard-dev/tw}
 
 stderr() { echo "$@" 1>&2; }
 fail() { [ $# -eq 0 ] || stderr "$@"; exit 1; }
@@ -62,7 +63,7 @@ main() {
 	cksum=$(git rev-parse "$tag") || fail "$tag did not exist"
 
 	# search only in lines 1 to 10 for version and epoch
-	sed -e "1,10s/^\([ ]\+version\): .*/\1: ${tag#v}/" \
+	sed -e "1,10s/^\([ ]\+version\): .*/\1: \"${tag#v}\"/" \
 	    -e "1,10s,^\([ ]\+epoch\): .*,\1: 0," \
 	    -e "s,#wolfi#,," \
 	    -e "s,^\([ ]\+expected-commit\): .*$,\1: $cksum," \


### PR DESCRIPTION
*   Fix release-to-wolfi for version.
    
    the version wasn't getting quoted, which made it randomly
    different than the wolfi-preferred way.
    
    Also, take TWGIT from the environment to facilitate easier
    testing like
    
        $ git tag v0.13.0
        $ TWGIT=$PWD ./tools/release-to-wolfi v0.13.0 ~/src/wolfi-os
 *Fixup indentation in melange.yaml 