### PR TITLE
use the docker runner for build/test

### DIFF
--- a/.github/workflows/presubmit.yaml
+++ b/.github/workflows/presubmit.yaml
@@ -23,11 +23,17 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
       with:
-        go-version-file: './tw/go.mod'
+        go-version-file: './go.work'
         cache-dependency-path: '**/*.sum'
 
     - name: Build
       run: make build
 
     - name: Test all projects
-      run: make test
+      run: |
+        ls -laht $HOME/go/pkg/mod
+        
+        # make build chowns is b/c its written to in docker which runs as root
+        sudo chown -R $(id -u):$(id -g) $HOME/go/pkg/mod
+
+        make test

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ ifeq (${ARCH}, arm64)
 	ARCH = aarch64
 endif
 
-PROJECT_DIRS := $(patsubst ./%,%,$(shell find . -maxdepth 1 -type d -not -path "." -not -path "./.*" -not -path "./tools"))
+PROJECT_DIRS := $(patsubst ./%,%,$(shell find . -maxdepth 1 -type d -not -path "." -not -path "./.*" -not -path "./tools" -not -path "./packages"))
 
 DIR_TESTS := $(addprefix test-, $(PROJECT_DIRS))
 
@@ -34,11 +34,11 @@ ${KEY}:
 	${MELANGE} keygen ${KEY}
 
 build: $(KEY)
-	$(MELANGE) build melange.yaml $(MELANGE_OPTS) $(MELANGE_BUILD_OPTS)
+	$(MELANGE) build --runner docker melange.yaml $(MELANGE_OPTS) $(MELANGE_BUILD_OPTS)
 
 test-%:
 	@echo "Running test in $*"
 	@$(MAKE) -C $* test
 
 test: $(KEY) $(DIR_TESTS)
-	$(MELANGE) test melange.yaml $(MELANGE_OPTS) $(MELANGE_TEST_OPTS)
+	$(MELANGE) test --runner docker melange.yaml $(MELANGE_OPTS) $(MELANGE_TEST_OPTS)


### PR DESCRIPTION
this is just a presubmit check to **test** whether melange can build/test, so we just leverage the `docker` runner instead of bwrap since docker is presintalled on GHA hosted runners and the bwrap install takes a minute.

this doesn't publish the apk anywhere