### PR TITLE
ensure oci repo works, and add some lightweight integration tests

### DIFF
--- a/tw/pkg/commands/helm/helm_test.go
+++ b/tw/pkg/commands/helm/helm_test.go
@@ -1,0 +1,38 @@
+package helm_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/chainguard-dev/tw/pkg/commands/helm"
+	"github.com/rogpeppe/go-internal/testscript"
+)
+
+func TestMain(m *testing.M) {
+	testscript.Main(m, map[string]func(){
+		"helm-inventory": helm_inventory_main,
+	})
+}
+
+func helm_inventory_main() {
+	cmd := helm.Command()
+	if err := cmd.Execute(); err != nil {
+		os.Exit(1)
+	}
+	os.Exit(0)
+}
+
+func TestHelmInventory(t *testing.T) {
+	testscript.Run(t, testscript.Params{
+		Dir: filepath.Join("testdata", "helm-inventory"),
+		Setup: func(e *testscript.Env) error {
+			e.Vars = append(e.Vars,
+				"HELM_CACHE_HOME=$WORK/helm-cache",
+				"HELM_REPOSITORY_CACHE=$WORK/helm-cache",
+				"HELM_CONFIG_HOME=$WORK/helm-config",
+			)
+			return nil
+		},
+	})
+}

--- a/tw/pkg/commands/helm/inventory_test.go
+++ b/tw/pkg/commands/helm/inventory_test.go
@@ -113,6 +113,31 @@ func TestHelmCommand(t *testing.T) {
 			},
 			expectError: false,
 		},
+		{
+			name: "install with OCI reference",
+			args: []string{"helm", "install", "my-release", "oci://ghcr.io/stefanprodan/charts/podinfo", "--version", "6.3.5"},
+			expected: &helmOpts{
+				op:        "install",
+				name:      "my-release",
+				chart:     "oci://ghcr.io/stefanprodan/charts/podinfo",
+				namespace: "default",
+				version:   "6.3.5",
+				values:    []string{},
+			},
+			expectError: false,
+		},
+		{
+			name: "install from chart repository with full URL specified",
+			args: []string{"helm", "install", "my-release", "https://charts.example.com/stable/podinfo-6.3.5.tgz"},
+			expected: &helmOpts{
+				op:        "install",
+				name:      "my-release",
+				chart:     "https://charts.example.com/stable/podinfo-6.3.5.tgz",
+				namespace: "default",
+				values:    []string{},
+			},
+			expectError: false,
+		},
 	}
 
 	for _, tc := range testCases {

--- a/tw/pkg/commands/helm/testdata/helm-inventory/local-chart.txtar
+++ b/tw/pkg/commands/helm/testdata/helm-inventory/local-chart.txtar
@@ -1,0 +1,22 @@
+helm-inventory --path inventory.json -f foochart/values.yaml -- helm template foo foochart --namespace default -f foochart/values.yaml
+cmp inventory.json inventory.golden.json
+
+-- foochart/Chart.yaml --
+apiVersion: v2
+name: test-chart
+version: 1.0.0
+description: Test chart for helm-inventory
+
+-- foochart/templates/deployment.tpl --
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: foo
+spec:
+  replicas: {{ .Values.replicas }}
+
+-- foochart/values.yaml --
+replicas: 2
+
+-- inventory.golden.json --
+{"chart":{"name":"test-chart","version":"1.0.0","repository":"","local":true},"values":{"replicas":2}}

--- a/tw/pkg/commands/helm/testdata/helm-inventory/oci-repo.txtar
+++ b/tw/pkg/commands/helm/testdata/helm-inventory/oci-repo.txtar
@@ -1,0 +1,5 @@
+helm-inventory --path inventory.json -- helm template release oci://ghcr.io/stefanprodan/charts/podinfo --version 6.3.5 --namespace default --dry-run
+cmp inventory.json inventory.golden.json
+
+-- inventory.golden.json --
+{"chart":{"name":"podinfo","version":"6.3.5","repository":"oci://ghcr.io/stefanprodan/charts/podinfo","digest":"sha256:40f563c2c63c8246c2728ecb69d5c95b105f5f3dfe9ab17b30171298b3d7743a"},"values":{}}

--- a/tw/pkg/commands/helm/testdata/helm-inventory/standard-repo.txtar
+++ b/tw/pkg/commands/helm/testdata/helm-inventory/standard-repo.txtar
@@ -1,0 +1,5 @@
+helm-inventory --path inventory.json -- helm template release podinfo --repo https://stefanprodan.github.io/podinfo --version 6.3.5 --namespace default --dry-run
+cmp inventory.json inventory.golden.json
+
+-- inventory.golden.json --
+{"chart":{"name":"podinfo","version":"6.3.5","repository":"https://stefanprodan.github.io/podinfo","digest":"sha256:e54d4cc7441b7f7fe3634167439641428c2e374a5970c705125cd5167e09a688"},"values":{}}


### PR DESCRIPTION
there's waaaaay too many ways to specify a chart repository. its madness.

this PR adds yet another format, the `helm install <name> <oci://>` one.

it also adds the framework for running some lightweight integration tests for the install variations we want to support.