### PR TITLE
fix: check all expressions before moving to next line

### DIFF
--- a/tw/pkg/commands/dgrep/dgrep.go
+++ b/tw/pkg/commands/dgrep/dgrep.go
@@ -151,7 +151,6 @@ func (c *cfg) retryableRun(ctx context.Context) error {
 					Text:      re.ReplaceAllStringFunc(line, c.highlighter),
 				})
 				matchedPatterns[i] = true
-				break
 			}
 		}
 	}

--- a/tw/pkg/commands/kgrep/kgrep.go
+++ b/tw/pkg/commands/kgrep/kgrep.go
@@ -143,7 +143,6 @@ func (c *cfg) retryableRun(ctx context.Context) error {
 						Text:      re.ReplaceAllStringFunc(line, c.highlighter),
 					})
 					matchedPatterns[i] = true
-					break
 				}
 			}
 		}


### PR DESCRIPTION
After the recent change, I am encountering this error where 
These pass: 
```
bash-5.2# tw kgrep -n kube-system deployment/kube-metrics-adapter -e "prometheus"
...
2025/06/20 08:22:19 INFO kgrep succeeded resource="[deployment kube-metrics-adapter]" namespace=kube-system attempt=1 timeout=5s
```

```
bash-5.2# tw kgrep -n kube-system deployment/kube-metrics-adapter -e "Collected new external metric"
...
2025/06/20 08:23:08 INFO kgrep succeeded resource="[deployment kube-metrics-adapter]" namespace=kube-system attempt=1 timeout=5s
```

This fails:
```
bash-5.2# tw kgrep -n kube-system deployment/kube-metrics-adapter -e "Collected new external metric" -e "prometheus"
...
2025/06/20 08:24:08 ERROR [1/1] failed to run kgrep: no match found for pattern(s): [prometheus] resource="[deployment kube-metrics-adapter]" namespace=kube-system
Error: kgrep failed after 1 attempt(s)
2025/06/20 08:24:08 ERROR failed to execute command: kgrep failed after 1 attempt(s)
```

This is because kgrep and dgrep stop at first match. This started failing after the recent change.

Log line I am trying to match
Tt has `prometheus` and `Collected new external metric` in one
```
2025/06/20 08:30:05 INFO -- [300/300] in kube-metrics-adapter-85b6fdcf6-f2245/kube-system: time="2025-06-20T08:30:04Z" level=info msg="Collected new external metric 'kube-system/demo' (0) [type=prometheus]" provider=hpa
```