### PR TITLE
fix(melange.yaml/syspeek): remove unneded runtime deps and add test

### DIFF
--- a/melange.yaml
+++ b/melange.yaml
@@ -112,19 +112,24 @@ subpackages:
       no-provides: true
     dependencies:
       runtime:
-        - apk-tools
         - binutils
-        - busybox
         - linux-headers
         - posix-libc-utils
     pipeline:
       - runs: |
           make -C syspeek-tool MELANGE_CONTEXTDIR=${{targets.contextdir}} melange-install
     test:
+      environment:
+        contents:
+          packages:
+            - crane # We just need an executable with the .text section not being discarded.
       pipeline:
         - runs: |
             [ -f /usr/bin/syspeek ]
             [ -x /usr/bin/syspeek ]
+        - runs: |
+            syspeek $(command -v crane) >syscalls.txt
+            [ -s syscalls.txt ]
 
   - name: usrmerge-tool
     options:


### PR DESCRIPTION
The `syspeek` tool doesn't need `apk-tools` and `busybox`, so we remove those runtime dependencies.
Also, the test wasn't actually testing anytihng from a functional perspective, so we add a test.