### PR TITLE
Workflows - run chainguard/apt-faster action.

### DIFF
--- a/.github/workflows/presubmit.yaml
+++ b/.github/workflows/presubmit.yaml
@@ -18,6 +18,7 @@ jobs:
         egress-policy: audit
 
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+    - uses: chainguard-dev/actions/apt-faster@ae2f0393ff2a60c572ff4d3485f406e8f36dfd38 # v1.4.6
     - uses: chainguard-dev/actions/setup-melange@ae2f0393ff2a60c572ff4d3485f406e8f36dfd38 # v1.4.6
 
     - name: Set up Go


### PR DESCRIPTION
See https://github.com/chainguard-dev/actions/tree/main/apt-faster for more info.

The 'setup melange' does installation of apt packages. This will make that go faster.