### PR TITLE
verify-service: fix default case of empty skip-files

### DIFF
--- a/pipelines/test/tw/verify-service.yaml
+++ b/pipelines/test/tw/verify-service.yaml
@@ -17,5 +17,5 @@ pipeline:
     runs: |
       verify-service \
       --dir ${{targets.contextdir}} \
-      --skip-files ${{inputs.skip-files}} \
+      --skip-files '${{inputs.skip-files}}' \
       --man ${{inputs.man}}


### PR DESCRIPTION
In the default case, the skip-files input is the empty string. This causes the argument parsing of the verify-service script to get out of sync, since its --skip-files option always expects an argument:

    2025/08/11 23:01:35 INFO running step "Verify Service files"
    2025/08/11 23:01:35 WARN + '[' -d /home/build ]
    2025/08/11 23:01:35 WARN + cd /home/build
    2025/08/11 23:01:35 WARN + verify-service --dir /home/build/melange-out/amazon-eks-ami-fips --skip-files --man false
    [                                                                                           ^^^^^^^^^^^^^^^^^^     ]
    [...]
    2025/08/11 23:01:35 INFO Skipping files: (--man)
    [...]
    2025/08/11 23:01:35 WARN + skip_expr=
    2025/08/11 23:01:35 WARN + skip_expr='|--man'
    2025/08/11 23:01:35 WARN + skip_expr='(--man)'
    [...]
    2025/08/11 23:01:35 WARN + echo 'Skipping files: (--man)'
    [...]
    2025/08/11 23:01:35 WARN + systemd-analyze verify '--man=' usr/lib/systemd/system/cni-cache-reset.service
    2025/08/11 23:01:35 WARN Failed to parse boolean argument to --man: .

Fix this by always quoting the interpolation of the skip-files input, so as to prevent the shell's word splitting from eliding the argument to --skip-files. The script can already handle the empty argument.