### PR TITLE
Rename presubmit to c-i and run as post-submit also.

### DIFF
--- a/.github/workflows/c-i.yaml
+++ b/.github/workflows/c-i.yaml
@@ -34,12 +34,16 @@ jobs:
       with:
         version: v0.10.0
 
-    - name: Build
-      run: make build
-
     - name: shellcheck
       run: make shellcheck
+
+    - name: Build
+      run: make build
 
     - name: Test all projects
       run: |
         make test
+
+    - name: Test in melange
+      run: |
+        make test-melange

--- a/.github/workflows/c-i.yaml
+++ b/.github/workflows/c-i.yaml
@@ -1,6 +1,8 @@
-name: Presubmit
+name: c-i
 
 on:
+  push:
+    branches: [ 'main' ]
   pull_request:
     branches: [ 'main' ]
 

--- a/Makefile
+++ b/Makefile
@@ -18,18 +18,18 @@ OUT_DIR ?= $(shell pwd)/packages
 WOLFI_REPO ?= https://packages.wolfi.dev/os
 WOLFI_KEY ?= https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
 
-MELANGE_OPTS += --arch ${ARCH}
-MELANGE_OPTS += --keyring-append ${KEY}.pub
-MELANGE_OPTS += --repository-append ${REPO}
-MELANGE_OPTS += -k ${WOLFI_KEY}
-MELANGE_OPTS += -r ${WOLFI_REPO}
-MELANGE_OPTS += --source-dir ./
+MELANGE_OPTS += --arch=${ARCH}
+MELANGE_OPTS += --keyring-append=${KEY}.pub
+MELANGE_OPTS += --repository-append=${REPO}
+MELANGE_OPTS += --keyring-append=${WOLFI_KEY}
+MELANGE_OPTS += --repository-append=${WOLFI_REPO}
+MELANGE_OPTS += --source-dir=./
 
-MELANGE_BUILD_OPTS += --signing-key ${KEY}
-MELANGE_BUILD_OPTS += --cache-dir $(HOME)/go/pkg/mod
-MELANGE_BUILD_OPTS += --out-dir ${OUT_DIR}
+MELANGE_BUILD_OPTS += --signing-key=${KEY}
+MELANGE_BUILD_OPTS += --cache-dir=$(HOME)/go/pkg/mod
+MELANGE_BUILD_OPTS += --out-dir=${OUT_DIR}
 
-MELANGE_TEST_OPTS += --test-package-append wolfi-base
+MELANGE_TEST_OPTS += --test-package-append=wolfi-base
 
 ${KEY}:
 	${MELANGE} keygen ${KEY}
@@ -37,7 +37,9 @@ ${KEY}:
 build: $(KEY)
 	$(MELANGE) build --runner docker melange.yaml $(MELANGE_OPTS) $(MELANGE_BUILD_OPTS)
 
-test-%:
+test: $(DIR_TESTS)
+.PHONY: $(DIR_TESTS)
+$(DIR_TESTS): test-%:
 	@echo "Running test in $*"
 	@$(MAKE) -C $* test
 
@@ -54,5 +56,5 @@ shellcheck:
 	    shellcheck "$$s" || rc=$$?; \
 	done; exit $$rc
 
-test: $(KEY) $(DIR_TESTS)
-	$(MELANGE) test --runner docker melange.yaml $(MELANGE_OPTS) $(MELANGE_TEST_OPTS)
+test-melange: $(KEY)
+	$(MELANGE) test --runner=docker melange.yaml $(MELANGE_OPTS) $(MELANGE_TEST_OPTS)

--- a/melange.yaml
+++ b/melange.yaml
@@ -1,6 +1,6 @@
 package:
   name: tw
-  version: "0.0.0"
+  version: "999.0.0_git"
   epoch: 0
   description: Testing tools
   options:


### PR DESCRIPTION
 *  Add test-melange to c-i

 *  Makefile: separate test-melange from test-subdir
    
    Also here, we now get tab completion for test-<subdir>.

 *  build - make local dev version of 999 so these packages are selected.
    
    test in c-i was choosing to install the wolfi packages over the local
    packages that it built because the local ones were versioned 0.0.0.
    
    Make local build versions newer than wolfi versions.

 *  Rename presubmit to c-i and run as post-submit also.
    
    We were not doing anything on post-submit, lets just do
    the same thing as pre-submit.
