### PR TITLE
Make sure yaml files are formatted with yam

### DIFF
--- a/.github/actions/shellcheck/action.yaml
+++ b/.github/actions/shellcheck/action.yaml
@@ -1,7 +1,5 @@
-# Copyright 2025 Chainguard, Inc.
-# SPDX-License-Identifier: Apache-2.0
-
 name: 'Setup shellcheck'
+
 description: |
   Install shellcheck into /usr/local/bin
 
@@ -13,7 +11,6 @@ inputs:
 
 runs:
   using: 'composite'
-
   steps:
     - name: "Install shellcheck"
       shell: bash
@@ -63,7 +60,6 @@ runs:
         mkdir -p "$XDIR"
         tar -C "$XDIR" --strip-components=1 -xvf "$fname" \
             "shellcheck-$VERSION/shellcheck"
-
     - name: "Show shellcheck info"
       shell: bash
       run: |

--- a/.github/workflows/c-i.yaml
+++ b/.github/workflows/c-i.yaml
@@ -31,8 +31,8 @@ jobs:
         uses: ./.github/actions/shellcheck
         with:
           version: v0.10.0
-      - name: shellcheck
-        run: make shellcheck
+      - name: lint
+        run: make lint
       - name: Build
         run: make build
       - name: Test all projects

--- a/.github/workflows/c-i.yaml
+++ b/.github/workflows/c-i.yaml
@@ -15,37 +15,29 @@ jobs:
   test:
     name: Test Projects
     runs-on: ubuntu-latest
-
     steps:
-    - uses: step-security/harden-runner@ec9f2d5744a09debf3a187a3f4f675c53b671911 # v2.13.0
-      with:
-        egress-policy: audit
-
-    - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-    - uses: chainguard-dev/actions/apt-faster@b1933e3d1f574c772dc7efd68c2060dafbc25e8c # v1.4.9
-    - uses: chainguard-dev/actions/setup-melange@b1933e3d1f574c772dc7efd68c2060dafbc25e8c # v1.4.9
-
-    - name: Set up Go
-      uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
-      with:
-        go-version-file: './go.work'
-        cache-dependency-path: '**/*.sum'
-
-    - name: Setup shellcheck
-      uses: ./.github/actions/shellcheck
-      with:
-        version: v0.10.0
-
-    - name: shellcheck
-      run: make shellcheck
-
-    - name: Build
-      run: make build
-
-    - name: Test all projects
-      run: |
-        make test
-
-    - name: Test in melange
-      run: |
-        make test-melange
+      - uses: step-security/harden-runner@ec9f2d5744a09debf3a187a3f4f675c53b671911 # v2.13.0
+        with:
+          egress-policy: audit
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - uses: chainguard-dev/actions/apt-faster@b1933e3d1f574c772dc7efd68c2060dafbc25e8c # v1.4.9
+      - uses: chainguard-dev/actions/setup-melange@b1933e3d1f574c772dc7efd68c2060dafbc25e8c # v1.4.9
+      - name: Set up Go
+        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
+        with:
+          go-version-file: './go.work'
+          cache-dependency-path: '**/*.sum'
+      - name: Setup shellcheck
+        uses: ./.github/actions/shellcheck
+        with:
+          version: v0.10.0
+      - name: shellcheck
+        run: make shellcheck
+      - name: Build
+        run: make build
+      - name: Test all projects
+        run: |
+          make test
+      - name: Test in melange
+        run: |
+          make test-melange

--- a/.github/workflows/c-i.yaml
+++ b/.github/workflows/c-i.yaml
@@ -2,9 +2,11 @@ name: c-i
 
 on:
   push:
-    branches: [ 'main' ]
+    branches:
+      - main
   pull_request:
-    branches: [ 'main' ]
+    branches:
+      - main
 
 permissions:
   contents: read

--- a/pipelines/test/tw/header-check.yaml
+++ b/pipelines/test/tw/header-check.yaml
@@ -1,4 +1,5 @@
 name: header-check
+
 needs:
   packages:
     - header-check


### PR DESCRIPTION
This adds some new targets to Makefile:
1. yam -  just have `yam` make your local directory happy.
2. yam-check - see if yam would make changes - exit 1 if it would.
3. lint - run the "lint" things (currently shellcheck and yam)

And now we run 'lint' target from c-i rather than just 'shellcheck'.

There is one less than perfect thing here in when we change the version of tools/bin/yam , the local version will just remain out of date.  Thats not a problem for c-i, but a local dev could be running with an out of date version.