### PR TITLE
Add verbose as an input for ver-check

### DIFF
--- a/pipelines/test/tw/ver-check.yaml
+++ b/pipelines/test/tw/ver-check.yaml
@@ -32,6 +32,11 @@ inputs:
       - 'regex': Use version as regex pattern
     required: false
     default: "contains"
+  verbose:
+    description: |
+      Whether or not the output should be verbose
+    required: false
+    default: false
 
 # USAGE EXAMPLES:
 #


### PR DESCRIPTION
The ver-check tests are not currently usable in Wolfi due to the missing verbose parameter:

```
 test:
   pipeline:
-    # AUTOGENERATED
-    - runs: |
-        getfacl --version
-        setfacl --version
+    - uses: test/tw/ver-check
+      with:
+        bins: getfacl setfacl
+    - name: Test help commands
+      runs: |
         getfacl --help
         setfacl --help
     - uses: test/no-docs
[ 11:06AM ]  [ brian-murray@log:~/src/wolfi-os(main✗) ]
 $ make test/acl                                                                               (main↑19966|✚3…6⚑2)
Makefile:21: ****************************** WARNING ******************************
Makefile:22: *** MELANGE_RUNNER is unset. The default runner is now qemu, which
Makefile:23: *** requires chainctl authentication to access the Chainguard kernel.
Makefile:24: *** See `melange build --help` for a list of other runner options.
Makefile:25: ****************************** WARNING ******************************
mkdir -p /tmp/melange-cache
mkdir -p ./acl/
Testing package acl with version acl-2.3.2-r54 from file acl.yaml
/home/brian-murray/go/bin//melange test acl.yaml --runner=qemu --repository-append /home/brian-murray/Working/wolfi
-os/packages --keyring-append local-melange.rsa.pub --arch x86_64 --pipeline-dirs ./pipelines/ --repository-append 
https://packages.wolfi.dev/os --keyring-append https://packages.wolfi.dev/os/wolfi-signing.rsa.pub --test-package-a
ppend wolfi-base --debug  --source-dir ./acl/
2025/09/02 11:06:17 ERRO ERROR: failed to test package. the test environment has been preserved:
2025/09/02 11:06:17 ERRO failed to test package: compiling acl.yaml tests: compiling "" test pipelines: compiling P
ipeline[0]: compiling Pipeline[0]: mutating runs: variable inputs.verbose not defined
make: *** [Makefile:180: test/acl] Error 1
```