### PR TITLE
verify-service - use subpkg.name rather than targets.contextdir

### DIFF
--- a/pipelines/test/tw/verify-service.yaml
+++ b/pipelines/test/tw/verify-service.yaml
@@ -16,6 +16,6 @@ pipeline:
   - name: Verify Service files
     runs: |
       verify-service \
-      --dir ${{targets.contextdir}} \
-      --skip-files '${{inputs.skip-files}}' \
-      --man ${{inputs.man}}
+        --package '${{subpkg.name}}' \
+        --skip-files '${{inputs.skip-files}}' \
+        --man ${{inputs.man}}

--- a/verify-service/verify-service
+++ b/verify-service/verify-service
@@ -12,7 +12,8 @@ Tool to check service files
 
 Options:
   -h, --help                    Show this help message and exit
-  --dir                         Dir to root of package check service files (required)
+  --dir                         Dir to root of package check service files [deprecated]
+  --package                     Package to search
   --skip-files                  Files to skip
   --man                         Wether or not to run the checks with man pages
 
@@ -26,6 +27,7 @@ EOF
 dir=""
 man=""
 skip_files=""
+package_name=""
 
 while [ $# -ne 0 ]; do
     case "$1" in
@@ -36,14 +38,20 @@ while [ $# -ne 0 ]; do
             shift;;
         --dir) dir="$2"
             shift;;
+        --package) package_name="$2"
+            shift;;
         --*) error "Unkown argument '$1'";;
     esac
     shift
 done
 
-if [ -z "$dir" ]; then
-    error "Required argument --dir missing"
+if [ -n "${package_name}" ] && [ -n "$dir" ]; then
+    error "Cannot provide --package and --dir"
+elif [ -n "$dir" ]; then
+    package_name=${dir##*/}
 fi
+
+[ -n "$package_name" ] || error "Must provide --package"
 
 set -x
 
@@ -64,10 +72,6 @@ Before=local-fs.target umount.target
 What=/dev/null
 Where=/test_instance
 EOF
-
-# ${{package.name}} when run inside of a test pipeline is always the name of the top-level
-# package. This seems like a bug to me.
-package_name=$(basename "$dir")
 
 skip_expr=""
 for skip in $skip_files; do


### PR DESCRIPTION
Use of targets.contextdir as input to a test pipeline confused me.  It was left over from a time when there was no subpkg.name. Now, use --package subpkg.name instead.