### PR TITLE
verify-service - use context.name, not subpkg.name

### DIFF
--- a/pipelines/test/tw/verify-service.yaml
+++ b/pipelines/test/tw/verify-service.yaml
@@ -16,6 +16,6 @@ pipeline:
   - name: Verify Service files
     runs: |
       verify-service \
-        --package '${{subpkg.name}}' \
+        --package '${{context.name}}' \
         --skip-files '${{inputs.skip-files}}' \
         --man ${{inputs.man}}


### PR DESCRIPTION
pr #188 made this use subpkg.name, it should have used context.name. subpkg.name is not valid for use in the main package.