### PR TITLE
no-docs-check: recommend use of combined split/alldocs pipeline

### DIFF
--- a/no-docs-check/main.go
+++ b/no-docs-check/main.go
@@ -100,9 +100,7 @@ func checkNoDocsViolations(packageName string) error {
 		}
 		fmt.Println()
 		fmt.Println("These files should be moved to a -doc subpackage.")
-		fmt.Println("Please add the following split pipeline(s):")
-		fmt.Println("  - split/manpages (for manual pages)")
-		fmt.Println("  - split/infodir (for GNU info pages)")
+		fmt.Println("Please add the split/alldocs pipeline.")
 		fmt.Println()
 		fmt.Printf("Total documentation files found: %d\n", len(docFiles))
 		return fmt.Errorf("documentation files found in package")


### PR DESCRIPTION
Recommend the use of the combined split/alldocs pipeline instead of individual pipeliens in the the new no-docs-check.