### PR TITLE
fix(byproduct): parse apk list output correctly and fix shellcheck warning

### DIFF
--- a/header-check/header-check
+++ b/header-check/header-check
@@ -14,7 +14,7 @@ error() {
 	exit 1
 }
 
-# shellcheck disable=SC2317
+# shellcheck disable=SC2317,SC2329
 cleanup() {
 	[ -n "$TEMP_D" ] || return 0
 	rm -Rf "$TEMP_D"

--- a/package-type-check/pkg/checkers/byproduct.go
+++ b/package-type-check/pkg/checkers/byproduct.go
@@ -6,7 +6,12 @@ import (
 	"strings"
 )
 
-// IsSameNamePackageInstalled checks if a package is really installed
+// IsSameNamePackageInstalled checks if a package with exactly this name is installed.
+// apk list --installed outputs lines like:
+//
+//	py3.13-altair-6.0.0-r2 aarch64 {py3-altair} (BSD-3-Clause) [installed]
+//
+// We check that the line starts with "<pkg>-" (name followed by version separator).
 func IsSameNamePackageInstalled(pkg string) (bool, error) {
 	cmd := exec.Command("apk", "list", "--installed", pkg)
 	output, err := cmd.Output()
@@ -14,13 +19,14 @@ func IsSameNamePackageInstalled(pkg string) (bool, error) {
 		return false, fmt.Errorf("failed to get installed version for package %q: %w", pkg, err)
 	}
 
-	// Split the output by lines and get the first line
-	lines := strings.Split(string(output), "\n")
-	if len(lines) == 0 || lines[0] == "" || strings.Compare(lines[0], pkg) != 0 {
-		return false, nil // Package not installed
+	prefix := pkg + "-"
+	for line := range strings.SplitSeq(strings.TrimSpace(string(output)), "\n") {
+		if line != "" && strings.HasPrefix(line, prefix) {
+			return true, nil
+		}
 	}
 
-	return true, nil
+	return false, nil
 }
 
 func CheckByProductPackage(pkg string) error {

--- a/tests/suites/byproductpackage.yaml
+++ b/tests/suites/byproductpackage.yaml
@@ -1,0 +1,17 @@
+name: Byproduct package pipeline validation tests
+
+description: Test suite for test/tw/byproductpackage pipeline
+
+testcases:
+  - name: A Valid Byproductpackage py3-altair
+    description: Verify byproductpackage pipeline pass
+    package: py3-altair
+    pipelines:
+      - uses: test/tw/byproductpackage
+    expect_pass: true
+  - name: An Invalid Byproductpackage py3.13-altair
+    description: Verify byproductpackage pipeline fails
+    package: py3.13-altair
+    pipelines:
+      - uses: test/tw/byproductpackage
+    expect_pass: false


### PR DESCRIPTION
- `IsSameNamePackageInstalled` was comparing full apk list output (e.g. "`py3.13-altair-6.0.0-r2 aarch64 {py3-altair} ...`") against the bare package name, so it never matched and every installable package incorrectly passed the byproduct check. Fix by checking if the output line starts with "<pkg>-" instead of exact string comparison.

- Also suppress SC2329 shellcheck warning in header-check for `cleanup()` which is invoked indirectly via trap.

Before this we meed to have the test framework merged:
- https://github.com/chainguard-dev/tw/pull/286
