### PR TITLE
Add '--installed' to invocations of apk info that query local db.

### DIFF
--- a/ldd-check/ldd-check
+++ b/ldd-check/ldd-check
@@ -209,9 +209,9 @@ check_file() {
 test_files_in() {
   local f=""
   echo "[ldd-check] Testing binaries in package $pkg"
-  apk info -eq "$pkg" > /dev/null ||
+  apk info --installed -q "$pkg" > /dev/null ||
     error "Package $pkg is not installed";
-  apk info -Lq "$pkg" > "$TEMP_D/$pkg.list"
+  apk info --installed -Lq "$pkg" > "$TEMP_D/$pkg.list"
   while read f; do
     [ -n "$f" ] || continue
     check_file "/$f" false

--- a/package-type-check/pkg/utils/package_utils.go
+++ b/package-type-check/pkg/utils/package_utils.go
@@ -9,7 +9,7 @@ import (
 
 // IsPackageInstalled checks if the package is installed
 func IsPackageInstalled(pkg string) error {
-	cmd := exec.Command("apk", "info", "-eq", pkg)
+	cmd := exec.Command("apk", "info", "--installed", "-q", pkg)
 	cmd.Stdout = nil
 	cmd.Stderr = nil
 	if err := cmd.Run(); err != nil {
@@ -20,7 +20,7 @@ func IsPackageInstalled(pkg string) error {
 
 // GetTotalApkCount retrieves the total count of installed APK packages in the environment
 func GetTotalApkCount() int {
-	cmd := exec.Command("apk", "info", "-L")
+	cmd := exec.Command("apk", "info", "--installed", "-L")
 	output, err := cmd.Output()
 	if err != nil {
 		return 0
@@ -44,7 +44,7 @@ func GetPackageFiles(pkg string) ([]string, error) {
 		return nil, err
 	}
 
-	cmd := exec.Command("apk", "info", "-qL", pkg)
+	cmd := exec.Command("apk", "info", "--installed", "-qL", pkg)
 	output, err := cmd.Output()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get files for package %q: %w", pkg, err)

--- a/tw/pkg/commands/shelldeps/check_package.go
+++ b/tw/pkg/commands/shelldeps/check_package.go
@@ -36,11 +36,11 @@ func (c *cfg) checkPackageCommand() *cobra.Command {
 		Long: `Analyze shell scripts installed by a package and check for dependency issues.
 
 This command:
-  - Gets the list of files installed by the package (using apk info -L)
+  - Gets the list of files installed by the package (using apk info --installed -L)
   - Identifies shell scripts among the installed files
   - Extracts dependencies from each shell script
   - Checks if dependencies are available in the search path
-  - Checks runtime dependencies (using apk info -R) to detect GNU/busybox compatibility issues
+  - Checks runtime dependencies (using apk info --installed -R) to detect GNU/busybox compatibility issues
   - Detects GNU-specific flags that don't work with busybox
   - Exits with non-zero status if any issues are found
 
@@ -141,10 +141,10 @@ type scriptSource struct {
 
 // getInstalledFiles returns the list of files installed by a package
 func (c *checkPackageCfg) getInstalledFiles(packageName string) ([]string, error) {
-	cmd := exec.Command("apk", "info", "-L", packageName)
+	cmd := exec.Command("apk", "info", "--installed", "-L", packageName)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
-		return nil, fmt.Errorf("apk info -L failed: %w (output: %s)", err, string(output))
+		return nil, fmt.Errorf("apk info --installed -L failed: %w (output: %s)", err, string(output))
 	}
 
 	lines := strings.Split(string(output), "\n")
@@ -172,7 +172,7 @@ func (c *checkPackageCfg) getInstalledFiles(packageName string) ([]string, error
 // getRuntimeDeps returns runtime dependencies for a package
 func (c *checkPackageCfg) getRuntimeDeps(packageName string) (runtimeDepsInfo, error) {
 	// Get dependencies from apk
-	cmd := exec.Command("apk", "info", "-R", packageName)
+	cmd := exec.Command("apk", "info", "--installed", "-R", packageName)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		return runtimeDepsInfo{}, fmt.Errorf("could not get deps from apk: %w (output: %s)", err, string(output))

--- a/verify-service/verify-service
+++ b/verify-service/verify-service
@@ -82,7 +82,7 @@ skip_expr="(${skip_expr#|})"
 echo "Package name: ${package_name}"
 echo "Skipping files: ${skip_expr}"
 service_files=$(mktemp)
-apk -L info "${package_name}" |
+apk info --installed -L "${package_name}" |
     grep -E 'usr/lib/systemd/system/.*.(service|socket)$' |
     grep -vE "/${skip_expr}$" > "${service_files}"
 


### PR DESCRIPTION
If you run 'apk info -L pkg' without '--installed', it will
read /var/cache/APKINDEX* files.   If you do have those files
this operation may take take several seconds. If you do not
have those files then it will write WARNING to stderr.

the WARNING can be avoided with `-q`, but it will still be slow.

In the changed cases here , we are intending to query the locally installed packages, so just be explicit and do that.