### PR TITLE
Fail chelm test when a declared digest is missing from rendered ref

### DIFF
--- a/chelm/cmd/test.go
+++ b/chelm/cmd/test.go
@@ -241,7 +241,17 @@ Exit code is non-zero if any test case fails.`,
 
 				// Check tag/digest matches per-imageID test values
 				expectedDigest := chelm.TestDigest(imageID).String()
-				if ref.Digest != "" && ref.Digest != expectedDigest {
+				// If cg.json declares a digest-bearing marker for this image,
+				// require the rendered ref to actually carry that digest.
+				// Catches template bugs that drop the digest entirely or
+				// produce a malformed digest tail the regex extractor
+				// silently truncates.
+				if chelm.DeclaresDigest(meta.Images[imageID]) {
+					if ref.Digest != expectedDigest {
+						caseOut.Passed = false
+						output.Passed = false
+					}
+				} else if ref.Digest != "" && ref.Digest != expectedDigest {
 					caseOut.Passed = false
 					output.Passed = false
 				}

--- a/chelm/internal/chelm/extract.go
+++ b/chelm/internal/chelm/extract.go
@@ -200,6 +200,12 @@ func (RegexExtractor) Extract(docs []map[string]any) []string {
 	var all []match
 	for _, p := range imagePatterns {
 		for _, loc := range p.FindAllIndex(raw, -1) {
+			// If the optional digest suffix failed to match and an '@' follows,
+			// the source has a malformed digest tail (e.g. @sha256:sha256:...).
+			// Skip rather than silently accept the truncated prefix as clean.
+			if loc[1] < len(raw) && raw[loc[1]] == '@' {
+				continue
+			}
 			all = append(all, match{
 				value: string(raw[loc[0]:loc[1]]),
 				start: loc[0],

--- a/chelm/internal/chelm/values.go
+++ b/chelm/internal/chelm/values.go
@@ -25,6 +25,33 @@ func TestDigest(imageID string) digest.Digest {
 	return digest.NewDigestFromBytes(digest.SHA256, h[:])
 }
 
+// DeclaresDigest reports whether img's values reference a marker whose
+// resolved value contains a digest: ${digest}, ${pseudo_tag} (tag@digest in
+// a tag-shaped slot), or ${ref} (repo@digest).
+func DeclaresDigest(img *images.Image) bool {
+	if img == nil || img.Values == nil {
+		return false
+	}
+	var found bool
+	m := &images.Mapping{Images: map[string]*images.Image{"_": img}}
+	// Abuse Walk for lexing: the SDK's lexer is unexported, but Walk recurses
+	// through values and hands us the TokenList for each string. The return
+	// value and any walk error are discarded — we only want the side effect.
+	_, _ = m.Walk(func(_ string, tokens images.TokenList) (any, error) {
+		for _, tok := range tokens {
+			f, ok := tok.(images.RefField)
+			if !ok {
+				continue
+			}
+			if f == images.Digest || f == images.PseudoTag || f == images.Ref {
+				found = true
+			}
+		}
+		return "", nil
+	})
+	return found
+}
+
 // GenerateValues creates Helm values for a test case.
 // Merges in order: image values < global test values < case values < extra values
 func GenerateValues(meta *CGMeta, caseName, testRegistry string, extra map[string]any) (map[string]any, error) {

--- a/chelm/testdata/test_double_prefix_digest.txtar
+++ b/chelm/testdata/test_double_prefix_digest.txtar
@@ -1,0 +1,48 @@
+# Chart template double-prefixes the digest, producing @sha256:sha256:<hex>.
+# Kubelet rejects this as InvalidImageName. The CR kind isn't in the
+# StructuredExtractor rule list, so only the regex extractor sees the ref.
+# chelm test must fail rather than silently truncate the malformed digest tail.
+! chelm test cg.json --chart=chart
+stdout '"passed": false'
+
+-- cg.json --
+{
+  "images": {
+    "prometheus": {
+      "values": {
+        "prometheus": {
+          "image": {
+            "repository": "${registry_repo}",
+            "tag": "${tag}",
+            "sha": "${digest}"
+          }
+        }
+      }
+    }
+  },
+  "test": {
+    "cases": [
+      {"name": "default", "images": ["prometheus"]}
+    ]
+  }
+}
+
+-- chart/Chart.yaml --
+apiVersion: v2
+name: test-chart
+version: 0.1.0
+
+-- chart/templates/prometheus.yaml --
+apiVersion: monitoring.coreos.com/v1
+kind: Prometheus
+metadata:
+  name: prometheus
+spec:
+  image: {{ .Values.prometheus.image.repository }}:{{ .Values.prometheus.image.tag }}@sha256:{{ .Values.prometheus.image.sha }}
+
+-- chart/values.yaml --
+prometheus:
+  image:
+    repository: quay.io/prometheus/prometheus
+    tag: v2.48.0
+    sha: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef

--- a/chelm/testdata/test_dropped_digest.txtar
+++ b/chelm/testdata/test_dropped_digest.txtar
@@ -1,0 +1,50 @@
+# cg.json declares ${digest} for the image but the chart template ignores it
+# and renders only :tag. Today the digest equality check is skipped when the
+# extracted ref has no digest, so the test passes silently. chelm test must
+# fail when a declared digest is missing from the rendered ref.
+! chelm test cg.json --chart=chart
+stdout '"passed": false'
+
+-- cg.json --
+{
+  "images": {
+    "app": {
+      "values": {
+        "image": {
+          "repository": "${registry_repo}",
+          "tag": "${tag}",
+          "digest": "${digest}"
+        }
+      }
+    }
+  },
+  "test": {
+    "cases": [
+      {"name": "default", "images": ["app"]}
+    ]
+  }
+}
+
+-- chart/Chart.yaml --
+apiVersion: v2
+name: test-chart
+version: 0.1.0
+
+-- chart/templates/deployment.yaml --
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test
+spec:
+  template:
+    spec:
+      containers:
+        - name: app
+          # Buggy template: declared digest is never written into the ref.
+          image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
+
+-- chart/values.yaml --
+image:
+  repository: nginx
+  tag: latest
+  digest: ""


### PR DESCRIPTION
A chart rendering <ref>:<tag>@sha256:sha256:<hex> silently passed: the regex extractor's optional @sha256:<hex> group rejected the malformed tail, truncated to the tag-only prefix, and the digest-equality check was gated on ref.Digest != "" so it never fired. Kubelet rejected the same image at runtime.

Fix in cmd/test.go: when cg.json declares a digest-bearing marker for an image, require the extracted ref's Digest to equal the expected one. Also drop regex matches followed by @ so the truncated prefix doesn't show up in the extraction as a clean ref.
