### PR TITLE
feat(gem-check): add --list flag to pass gem names for list check

### DIFF
--- a/gem-check/gem-check
+++ b/gem-check/gem-check
@@ -70,6 +70,7 @@ exit 9
 }
 
 package=""
+list=""
 require=""
 
 while [ $# -ne 0 ]; do
@@ -87,6 +88,13 @@ while [ $# -ne 0 ]; do
 			else
 				package="$2"
 			fi
+			shift
+		;;
+		-l=*|--list=*)
+			list="${1#*=}"
+		;;
+		-l|--list)
+			list="$2"
 			shift
 		;;
 		-r=*|--require=*)
@@ -111,7 +119,8 @@ while [ $# -ne 0 ]; do
 	shift
 done
 package=${package# }
-require=${require# }
+list=$(echo "${list# }" | tr ',' ' ')
+require=$(echo "${require# }" | tr ',' ' ')
 
 [ -n "${package}" ] || error "No package specified"
 
@@ -138,13 +147,27 @@ PASSES=0
 #   PASS[gem-check]: Success requiring gem [zip]
 #   INFO[gem-check]: tested [2] files with gem-check.  [2] passes. [0] fails.
 #
+# For meta-packages that bundle multiple gems, or where the apk name isn't
+# itself a gem, override or skip the list check with --list:
+#   $ gem-check --package=ruby3.2-foo --list="bar baz"
+#   $ gem-check --package=ruby3.2-foo --list=none --require=bar
+#
 gem_dash=$(echo "$package" | sed -e "s/^ruby[0-9\.]\+-//")
 gem_slash=$(echo "$package" | sed -e "s/^ruby[0-9\.]\+-//" -e "s:\-:/:g")
-# Test listing the gem
-if gem_list "$gem_dash" ; then
-	pass "Success listing gem [$gem_dash]"
+# Test listing the gem(s)
+if [ -z "$list" ]; then
+	list="$gem_dash"
+fi
+if [ "$list" = "none" ]; then
+	info "Skipping gem list check"
 else
-	fail "Failed listing gem [$gem_dash]"
+	for g in $list; do
+		if gem_list "$g" ; then
+			pass "Success listing gem [$g]"
+		else
+			fail "Failed listing gem [$g]"
+		fi
+	done
 fi
 # Test requiring the gem in ruby code
 if [ -z "$require" ]; then
@@ -158,7 +181,7 @@ for req in $require; do
 	fi
 done
 
-info "Tested [package='$package', require='$require'] with [$PROG].  [$PASSES/$((PASSES+FAILS))] passed."
+info "Tested [package='$package', list='$list', require='$require'] with [$PROG].  [$PASSES/$((PASSES+FAILS))] passed."
 if [ "$FAILS" = "0" ]; then
 	exit 0
 else

--- a/pipelines/test/tw/gem-check.yaml
+++ b/pipelines/test/tw/gem-check.yaml
@@ -20,6 +20,13 @@ inputs:
       Defaults to the current package being built.
     required: false
     default: "${{context.name}}"
+  list:
+    description: |
+      Exact gem name(s) to check with 'gem list -i' (space-separated).
+      Overrides the auto-detected name from the package.
+      Use 'none' to skip the list check entirely.
+    required: false
+    default: ""
   require:
     description: |
       Exact gem name(s) to test requiring (comma or space-separated).
@@ -43,7 +50,23 @@ inputs:
 #     with:
 #       require: "rails activerecord actionpack"
 #
+# Meta-package that bundles multiple gems whose names don't match the apk:
+#   - uses: test/tw/gem-check
+#     with:
+#       list: |
+#         fluent-plugin-oss
+#         fluent-plugin-foo
+#       require: |
+#         fluent/plugin/out_oss
+#         fluent/plugin/out_foo
+#
+# Meta-package, skipping the list check entirely:
+#   - uses: test/tw/gem-check
+#     with:
+#       list: none
+#       require: "fluent/plugin/out_oss"
+#
 pipeline:
   - name: check a ruby gem installation
     runs: |
-      gem-check --package "${{inputs.package}}" --require "${{inputs.require}}"
+      gem-check --package "${{inputs.package}}" --list "${{inputs.list}}" --require "${{inputs.require}}"


### PR DESCRIPTION
- Related: https://github.com/chainguard-dev/internal-dev/issues/26219

`gem-check` derives the `gem list -i` target from the apk package name (stripping ruby[0-9.]+-). This assumes a 1:1 mapping between apk name and gem name, which is not true for packages that bundle multiple gems.

Example: `ruby3.2-kube-logging-operator-fluentd-outputs` is a collection of fluentd output plugin gems. The apk name is not itself a gem, so the list check fails:
```
  FAIL[gem-check]: Failed listing gem [kube-logging-operator-fluentd-outputs]
  PASS[gem-check]: Success requiring gem [fluent/plugin/out_oss]
```

To fix this, we add a `--list` flag to gem-check:
  - `--list foo` / `--list "foo bar"` — check named gem(s) instead of the package-derived guess
  - `--list none` — skip the list check entirely
  - omitted/empty — current auto-detect behavior (so it won't break anything)
 
We could do something like:
```
- uses: test/tw/gem-check
  with:
    list: |
      fluent-plugin-oss
      fluent-plugin-foo
    require: |
      fluent/plugin/out_oss
      fluent/plugin/out_foo
```