### PR TITLE
feat(package-type-check): add configurable prefix for dev package header check

### DIFF
--- a/go.work.sum
+++ b/go.work.sum
@@ -1722,6 +1722,7 @@ golang.org/x/crypto v0.42.0/go.mod h1:4+rDnOTJhQCx2q7/j6rAN5XDw8kPjeaXEUR2eL94ix
 golang.org/x/crypto v0.44.0/go.mod h1:013i+Nw79BMiQiMsOPcVCB5ZIJbYkerPrGnOa00tvmc=
 golang.org/x/crypto v0.45.0/go.mod h1:XTGrrkGJve7CYK7J8PEww4aY7gM3qMCElcJQ8n8JdX4=
 golang.org/x/crypto v0.47.0/go.mod h1:ff3Y9VzzKbwSSEzWqJsJVBnWmRwRSHt/6Op5n9bQc4A=
+golang.org/x/crypto v0.51.0/go.mod h1:8AdwkbraGNABw2kOX6YFPs3WM22XqI4EXEd8g+x7Oc8=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190306152737-a1d7652674e8/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190510132918-efd6b22b2522/go.mod h1:ZjyILWgesfNpC6sMxTJOJm9Kp84zZh5NQWvqDGG3Qr8=
@@ -1977,6 +1978,7 @@ golang.org/x/sys v0.36.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=
 golang.org/x/sys v0.37.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=
 golang.org/x/sys v0.38.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=
 golang.org/x/sys v0.40.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=
+golang.org/x/sys v0.44.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/telemetry v0.0.0-20240521205824-bda55230c457/go.mod h1:pRgIJT+bRLFKnoM1ldnzKoxTIn14Yxz928LQRYYgIN0=
 golang.org/x/telemetry v0.0.0-20250710130107-8d8967aff50b/go.mod h1:4ZwOYna0/zsOKwuR5X/m0QFOJpSZvAxFfkQT+Erd9D4=
 golang.org/x/telemetry v0.0.0-20250908211612-aef8a434d053/go.mod h1:+nZKN+XVh4LCiA9DV3ywrzN4gumyCnKjau3NGb9SGoE=
@@ -1984,6 +1986,7 @@ golang.org/x/telemetry v0.0.0-20251111182119-bc8e575c7b54/go.mod h1:hKdjCMrbv9sk
 golang.org/x/telemetry v0.0.0-20260409153401-be6f6cb8b1fa/go.mod h1:kHjTxDEnAu6/Nl9lDkzjWpR+bmKfxeiRuSDlsMb70gE=
 golang.org/x/term v0.31.0 h1:erwDkOK1Msy6offm1mOgvspSkslFnIGsFnxOKoufg3o=
 golang.org/x/term v0.31.0/go.mod h1:R4BeIy7D95HzImkxGkTW1UQTtP54tio2RyHz7PwK0aw=
+golang.org/x/term v0.43.0/go.mod h1:lrhlHNdQJHO+1qVYiHfFKVuVioJIheAc3fBSMFYEIsk=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=

--- a/package-type-check/main.go
+++ b/package-type-check/main.go
@@ -109,14 +109,19 @@ func CheckByProductCommand() *cobra.Command {
 }
 
 func CheckDevCommand() *cobra.Command {
-	return &cobra.Command{
+	var prefix string
+
+	cmd := &cobra.Command{
 		Use:   "dev <PACKAGE>",
 		Short: "Check and verify the package is a dev package",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return checkers.CheckDevPackage(args[0])
+			return checkers.CheckDevPackage(args[0], prefix)
 		},
 	}
+
+	cmd.Flags().StringVar(&prefix, "prefix", "/usr", "Specify the prefix path for header files")
+	return cmd
 }
 
 func CheckDebugCommand() *cobra.Command {

--- a/package-type-check/pkg/checkers/dev.go
+++ b/package-type-check/pkg/checkers/dev.go
@@ -6,7 +6,7 @@ import (
 	"github.com/chainguard-dev/cg-tw/package-type-check/pkg/utils"
 )
 
-func CheckDevPackage(pkg string) error {
+func CheckDevPackage(pkg string, prefix string) error {
 	fmt.Printf("Checking if package %s is a valid dev package\n", pkg)
 
 	// Check 1: Package name must end with -dev or -devel
@@ -25,15 +25,15 @@ func CheckDevPackage(pkg string) error {
 	}
 	fmt.Printf("PASS [2/3]: Dev package [%s] is not empty\n", pkg)
 
-	// Check 3: Package should contain C/C++ header files under /usr
-	hasHeaders, err := utils.HasHeaderFiles(pkg)
+	// Check 3: Package should contain C/C++ header files under the specified prefix
+	hasHeaders, err := utils.HasHeaderFiles(pkg, prefix)
 	if err != nil {
 		return err
 	}
 	if !hasHeaders {
-		return fmt.Errorf("FAIL [3/3]: Dev package [%s] does not contain any header files (.h, .hpp, .hxx, .hh, .h++) under /usr", pkg)
+		return fmt.Errorf("FAIL [3/3]: Dev package [%s] does not contain any header files (.h, .hpp, .hxx, .hh, .h++) under %s", pkg, prefix)
 	}
-	fmt.Printf("PASS [3/3]: Dev package [%s] contains header files under /usr\n", pkg)
+	fmt.Printf("PASS [3/3]: Dev package [%s] contains header files under %s\n", pkg, prefix)
 
 	return nil
 }

--- a/package-type-check/pkg/utils/package_utils.go
+++ b/package-type-check/pkg/utils/package_utils.go
@@ -209,15 +209,16 @@ func isHeaderFile(file string) bool {
 	return false
 }
 
-// HasHeaderFiles checks if package contains C/C++ header files under /usr
-func HasHeaderFiles(pkg string) (bool, error) {
+// HasHeaderFiles checks if package contains C/C++ header files under the specified prefix
+func HasHeaderFiles(pkg string, prefix string) (bool, error) {
 	files, err := GetPackageFiles(pkg)
 	if err != nil {
 		return false, err
 	}
 
+	normalizedPrefix := NormalizePath(prefix)
 	for _, file := range files {
-		if strings.HasPrefix(file, "/usr/") && isHeaderFile(file) {
+		if strings.HasPrefix(file, normalizedPrefix) && isHeaderFile(file) {
 			return true, nil
 		}
 	}

--- a/package-type-check/pkg/utils/package_utils_test.go
+++ b/package-type-check/pkg/utils/package_utils_test.go
@@ -26,6 +26,16 @@ func TestNormalizePath(t *testing.T) {
 			path:     "",
 			expected: "/",
 		},
+		{
+			name:     "custom prefix for pyca cryptography",
+			path:     "/opt/pyca/cryptography/openssl",
+			expected: "/opt/pyca/cryptography/openssl",
+		},
+		{
+			name:     "prefix without leading slash",
+			path:     "opt/custom/path",
+			expected: "/opt/custom/path",
+		},
 	}
 
 	for _, tt := range tests {
@@ -65,6 +75,102 @@ func TestIsHeaderFile(t *testing.T) {
 			if result != tt.expected {
 				t.Errorf("isHeaderFile(%q) = %v, want %v",
 					tt.file, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestIsDevPackage(t *testing.T) {
+	tests := []struct {
+		name     string
+		pkg      string
+		expected bool
+	}{
+		{"package ending with -dev", "libssl-dev", true},
+		{"package ending with -devel", "kernel-devel", true},
+		{"regular package", "bash", false},
+		{"package with dev in middle", "devtools", false},
+		{"empty string", "", false},
+		{"package with -development", "python-development", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := IsDevPackage(tt.pkg)
+			if result != tt.expected {
+				t.Errorf("IsDevPackage(%q) = %v, want %v",
+					tt.pkg, result, tt.expected)
+			}
+		})
+	}
+}
+
+// TestHeaderFileWithPrefixMatching tests the logic for matching header files under different prefixes
+func TestHeaderFileWithPrefixMatching(t *testing.T) {
+	tests := []struct {
+		name           string
+		file           string
+		prefix         string
+		shouldMatch    bool
+		description    string
+	}{
+		{
+			name:        "standard header under /usr with /usr prefix",
+			file:        "/usr/include/openssl/ssl.h",
+			prefix:      "/usr",
+			shouldMatch: true,
+			description: "Standard case: header in /usr/include",
+		},
+		{
+			name:        "header under custom prefix matches",
+			file:        "/opt/pyca/cryptography/openssl/include/openssl/ssl.h",
+			prefix:      "/opt/pyca/cryptography/openssl",
+			shouldMatch: true,
+			description: "Custom prefix case: pyca cryptography OpenSSL headers",
+		},
+		{
+			name:        "header under /usr does not match /opt prefix",
+			file:        "/usr/include/openssl/ssl.h",
+			prefix:      "/opt/custom",
+			shouldMatch: false,
+			description: "Prefix mismatch: file not under specified prefix",
+		},
+		{
+			name:        "non-header file under prefix does not match",
+			file:        "/usr/lib/libssl.so",
+			prefix:      "/usr",
+			shouldMatch: false,
+			description: "Not a header file, should not match",
+		},
+		{
+			name:        "header under /opt with /usr prefix does not match",
+			file:        "/opt/custom/include/foo.h",
+			prefix:      "/usr",
+			shouldMatch: false,
+			description: "Header exists but under wrong prefix",
+		},
+		{
+			name:        "C++ header under custom prefix",
+			file:        "/opt/local/include/boost/algorithm.hpp",
+			prefix:      "/opt/local",
+			shouldMatch: true,
+			description: "C++ header under custom /opt/local prefix",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			normalizedPrefix := NormalizePath(tt.prefix)
+			hasPrefix := false
+			if len(tt.file) >= len(normalizedPrefix) {
+				hasPrefix = tt.file[:len(normalizedPrefix)] == normalizedPrefix
+			}
+			isHeader := isHeaderFile(tt.file)
+			matches := hasPrefix && isHeader
+
+			if matches != tt.shouldMatch {
+				t.Errorf("File %q with prefix %q: got match=%v, want match=%v\n  %s",
+					tt.file, tt.prefix, matches, tt.shouldMatch, tt.description)
 			}
 		})
 	}

--- a/pipelines/test/tw/devpackage.yaml
+++ b/pipelines/test/tw/devpackage.yaml
@@ -10,7 +10,16 @@ needs:
   packages:
     - package-type-check
 
+inputs:
+  prefix:
+    description: |
+      Prefix path where header files should be located.
+      Development packages typically install header files under /usr/include.
+      Change this if header files are installed in a non-standard location.
+    default: "/usr"
+
 pipeline:
   - name: Check if the package is a Dev Package
     runs: |
-      package-type-check dev "${{context.name}}"
+      package-type-check dev "${{context.name}}" \
+          --prefix "${{inputs.prefix}}"

--- a/tests/suites/devpackage.yaml
+++ b/tests/suites/devpackage.yaml
@@ -1,0 +1,40 @@
+name: Dev package pipeline validation tests
+
+description: Test suite for test/tw/devpackage pipeline
+
+testcases:
+  - name: Valid dev package zlib-dev with default prefix
+    description: Verify devpackage pipeline passes for zlib-dev with headers under /usr
+    package: zlib-dev
+    pipelines:
+      - uses: test/tw/devpackage
+    expect_pass: true
+  - name: Valid dev package ncurses-dev with default prefix
+    description: Verify devpackage pipeline passes for ncurses-dev with headers under /usr
+    package: ncurses-dev
+    pipelines:
+      - uses: test/tw/devpackage
+    expect_pass: true
+  # TODO: Uncomment once eco-python-openssl-4-pyca-dev is added to Wolfi
+  # This test validates the custom prefix functionality for packages with headers
+  # installed in non-standard locations like /opt/pyca/cryptography/openssl
+  # - name: Valid dev package with custom prefix
+  #   description: Verify devpackage pipeline passes for eco-python-openssl-4-pyca-dev with custom prefix
+  #   package: eco-python-openssl-4-pyca-dev
+  #   pipelines:
+  #     - uses: test/tw/devpackage
+  #       with:
+  #         prefix: /opt/pyca/cryptography/openssl
+  #   expect_pass: true
+  - name: Invalid dev package bash (not a dev package)
+    description: Verify devpackage pipeline fails for bash which is not a dev package
+    package: bash
+    pipelines:
+      - uses: test/tw/devpackage
+    expect_pass: false
+  - name: Invalid dev package glibc (not a dev package)
+    description: Verify devpackage pipeline fails for glibc which is not a dev package
+    package: glibc
+    pipelines:
+      - uses: test/tw/devpackage
+    expect_pass: false


### PR DESCRIPTION
# What
Add --prefix flag to the dev subcommand to allow specifying a custom path prefix for header file location checks. Previously hardcoded to /usr, this
can now be overridden for packages that install headers in non-standard locations.

The devpackage.yaml pipeline now accepts a prefix input (default: /usr) that is passed through to the checker.

# Why
I'm building an eco-python-openssl-4 package that installs under `/opt`, and I'd like to still use the `test/tw/devpackage` pipeline for it.

