### PR TITLE
chore: remove .claude directory and add to .gitignore

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,7 +1,0 @@
-{
-  "permissions": {
-    "allow": [
-      "Bash(go test:*)"
-    ]
-  }
-}

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.claude
 **/bin
 package-type-check/package-type-check
 packages/*


### PR DESCRIPTION
The .claude directory appears to have been added by accident.

Fixes: dcf9174b3fe3 ("package-type-check: normalize paths to always have a leading \"/\" symbol")

🤖 Generated with [Claude Code](https://claude.com/claude-code)