### PR TITLE
Use go.work for automatic module discovery in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,8 +11,6 @@ updates:
           - "patch"
 
   - package-ecosystem: "gomod"
-    directories:
-      - "/*"
-      - "/*/*"
+    directory: "/"
     schedule:
       interval: "daily"


### PR DESCRIPTION
Simplify dependabot.yml to use a single directory entry rather than manually enumerating module paths. Dependabot v0.374.0+ automatically discovers all modules from go.work, eliminating the need to update dependabot.yml when modules are added or removed.

## What This Improves

✅ **Automatic module discovery** - Dependabot reads go.work and finds all workspace modules  
✅ **Self-maintaining configuration** - Adding/removing modules doesn't require dependabot.yml updates  
✅ **Consistent updates** - All workspace modules are updated together

## Current Limitation

⚠️ **go.work itself is not yet automatically updated** when Go versions change (see [dependabot/dependabot-core#6012](https://github.com/dependabot/dependabot-core/issues/6012))

Manual intervention is still required to update the `go` directive in `go.work` when reviewing PRs that bump the Go version. This can be done with:
```bash
go work use
```

## Testing

Tested on fork: Dependabot correctly discovered all 8 workspace modules and updated their go.mod files in [dannf/tw#11](https://github.com/dannf/tw/pull/11), but did not update go.work (confirming the limitation above).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>

Signed-off-by: dann frazier <dann.frazier@chainguard.dev>