### PR TITLE
chore: workflows: actions/checkout: set persist-credentials=false

### DIFF
--- a/.github/workflows/c-i.yaml
+++ b/.github/workflows/c-i.yaml
@@ -27,6 +27,8 @@ jobs:
         with:
           egress-policy: audit
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: chainguard-dev/actions/apt-faster@e1c4977ad9cb32b12c5b222ec0134a22bec60bd5 # v1.6.25
       - uses: chainguard-dev/actions/setup-melange@e1c4977ad9cb32b12c5b222ec0134a22bec60bd5 # v1.6.25
       - name: Set up Go


### PR DESCRIPTION
Recommended by `github-advanced-security` alert.

Signed-off-by: dann frazier <dann.frazier@chainguard.dev>
